### PR TITLE
feat(python): implement SSE stream auto-reconnection for resumable endpoints

### DIFF
--- a/generators/python/core_utilities/shared/http_sse/__init__.py
+++ b/generators/python/core_utilities/shared/http_sse/__init__.py
@@ -1,4 +1,12 @@
-from ._api import MAX_LINE_SIZE, EventSource, aconnect_sse, connect_sse
+from ._api import (
+    DEFAULT_MAX_RECONNECTION_ATTEMPTS,
+    DEFAULT_RECONNECT_DELAY_MS,
+    MAX_LINE_SIZE,
+    MAX_RECONNECT_DELAY_MS,
+    EventSource,
+    aconnect_sse,
+    connect_sse,
+)
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
@@ -7,6 +15,9 @@ __version__ = "0.4.1"
 __all__ = [
     "__version__",
     "MAX_LINE_SIZE",
+    "DEFAULT_MAX_RECONNECTION_ATTEMPTS",
+    "DEFAULT_RECONNECT_DELAY_MS",
+    "MAX_RECONNECT_DELAY_MS",
     "EventSource",
     "connect_sse",
     "aconnect_sse",

--- a/generators/python/core_utilities/shared/http_sse/_api.py
+++ b/generators/python/core_utilities/shared/http_sse/_api.py
@@ -1,14 +1,42 @@
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -19,11 +47,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -68,14 +100,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -90,6 +203,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -109,48 +255,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/generators/python/core_utilities/shared/http_sse/_api.py
+++ b/generators/python/core_utilities/shared/http_sse/_api.py
@@ -111,24 +111,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -276,13 +290,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -358,11 +376,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -399,7 +421,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/generators/python/core_utilities/shared/http_sse/_api.py
+++ b/generators/python/core_utilities/shared/http_sse/_api.py
@@ -26,11 +26,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -143,43 +138,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -279,7 +248,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -292,8 +280,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -339,7 +325,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -352,8 +355,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/generators/python/core_utilities/shared/http_sse/_api.py
+++ b/generators/python/core_utilities/shared/http_sse/_api.py
@@ -26,14 +26,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -52,16 +49,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -95,8 +108,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -263,10 +276,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -296,8 +313,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -306,7 +324,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -340,8 +358,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -368,13 +390,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/generators/python/core_utilities/shared/http_sse/_decoders.py
+++ b/generators/python/core_utilities/shared/http_sse/_decoders.py
@@ -10,6 +10,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/generators/python/sdk/changes/unreleased/sse-auto-reconnection.yml
+++ b/generators/python/sdk/changes/unreleased/sse-auto-reconnection.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Implement transparent SSE stream auto-reconnection for `resumable: true`
+    endpoints, bringing the Python SDK to parity with TypeScript and Go. When a
+    resumable stream ends prematurely, `EventSource` now re-issues the original
+    request with a `Last-Event-ID` header and resumes from the last *dispatched*
+    event id (never a parsed-but-undispatched id, avoiding silent event loss).
+    Reconnection is gated on a configured stream terminator, honors
+    `stream_reconnection_enabled` and `max_stream_reconnection_attempts` (with
+    reset-on-progress), backs off 1s by default (or the server `retry:` value,
+    clamped to 30s), guards against empty reconnect bodies, and remains
+    cancellable during the backoff delay. Supported for both sync and async
+    clients.
+  type: feat

--- a/generators/python/src/fern_python/external_dependencies/httpx.py
+++ b/generators/python/src/fern_python/external_dependencies/httpx.py
@@ -73,8 +73,12 @@ class HttpX:
         reference_to_client: AST.Expression,
         is_default_body_parameter_used: bool,
         force_multipart: bool = False,
+        emit_sse_reconnect: bool = False,
+        reconnect_variable_name: str = "_reconnect",
     ) -> AST.Expression:
-        def add_request_params(*, writer: AST.NodeWriter) -> None:
+        last_event_id_param = "last_event_id"
+
+        def add_request_params(*, writer: AST.NodeWriter, reconnect_last_event_id_var: Optional[str] = None) -> None:
             if query_parameters is not None:
                 writer.write("params=")
                 writer.write_node(query_parameters)
@@ -100,7 +104,18 @@ class HttpX:
                 writer.write_node(content)
                 writer.write_line(",")
 
-            if headers is not None:
+            if reconnect_last_event_id_var is not None:
+                # Reconnect re-issues the original request, adding the
+                # Last-Event-ID header so the server resumes the stream.
+                writer.write("headers=")
+                if headers is not None:
+                    writer.write("{**(")
+                    writer.write_node(headers)
+                    writer.write(f' or {{}}), "Last-Event-ID": {reconnect_last_event_id_var}}}')
+                else:
+                    writer.write(f'{{"Last-Event-ID": {reconnect_last_event_id_var}}}')
+                writer.write_line(",")
+            elif headers is not None:
                 writer.write("headers=")
                 writer.write_node(headers)
                 writer.write_line(",")
@@ -144,6 +159,28 @@ class HttpX:
                 add_request_params(writer=writer)
             writer.write_line(")")
 
+        def write_reconnect_closure(*, writer: AST.NodeWriter) -> None:
+            # A closure that re-issues the original streaming request with a
+            # Last-Event-ID header. Returns the streaming context manager (sync
+            # or async) so EventSource can transparently resume a dropped stream.
+            writer.write_line(f"def {reconnect_variable_name}({last_event_id_param}: str):")
+            with writer.indent():
+                writer.write("return ")
+                writer.write_node(reference_to_client)
+                writer.write_line(".stream(")
+                with writer.indent():
+                    if path is not None:
+                        writer.write_node(path)
+                        writer.write(",")
+                    if url is not None:
+                        writer.write("base_url=")
+                        writer.write_node(url)
+                        writer.write(",")
+                    writer.write_line(f'method="{method}",')
+                    add_request_params(writer=writer, reconnect_last_event_id_var=last_event_id_param)
+                writer.write_line(")")
+            writer.write_newline_if_last_line_not()
+
         def write_streaming_call(*, writer: AST.NodeWriter) -> None:
             if is_async:
                 writer.write("async ")
@@ -164,6 +201,8 @@ class HttpX:
             writer.write_line(f") as {response_variable_name}:")
 
             with writer.indent():
+                if emit_sse_reconnect:
+                    write_reconnect_closure(writer=writer)
                 writer.write_node(
                     AST.FunctionDeclaration(
                         name=HttpX.STREAM_FUNC_NAME,

--- a/generators/python/src/fern_python/generators/sdk/client_generator/constants.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/constants.py
@@ -6,3 +6,8 @@ CHUNK_VARIABLE: Final[str] = "_chunk"
 DEFAULT_BODY_PARAMETER_VALUE = "OMIT"
 
 RESPONSE_VARIABLE: Final[str] = "_response"
+
+# Name of the closure generated for resumable SSE endpoints that re-issues the
+# original request (with a ``Last-Event-ID`` header) so ``EventSource`` can
+# transparently reconnect a dropped stream.
+SSE_RECONNECT_VARIABLE: Final[str] = "_reconnect"

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
@@ -640,6 +640,11 @@ class EndpointFunctionGenerator:
                 last_param = named_parameters[-1]
                 request_options_variable_name = last_param.name
 
+            # The actual request-options parameter name (before any retries
+            # override below), used by the response-body code writer to read
+            # option keys like ``chunk_size``/``stream_reconnection_enabled``.
+            request_options_parameter_name = request_options_variable_name
+
             if endpoint.retries is not None:
                 if isinstance(endpoint.retries, ir_types.RetriesDisabledSchema) and endpoint.retries.disabled:
                     overridden_request_options_var = "_request_options_with_retries_disabled"
@@ -721,6 +726,7 @@ class EndpointFunctionGenerator:
                         is_raw_client=self._is_raw_client,
                         http_method=method,
                         client_wrapper_member_name=self._client_wrapper_member_name,
+                        request_options_variable_name=request_options_parameter_name,
                     )
                     streaming_request = get_httpx_request(
                         is_streaming=True,
@@ -760,6 +766,7 @@ class EndpointFunctionGenerator:
                     is_raw_client=self._is_raw_client,
                     http_method=method,
                     client_wrapper_member_name=self._client_wrapper_member_name,
+                    request_options_variable_name=request_options_parameter_name,
                 )
                 non_streaming_request = get_httpx_request(
                     is_streaming=False,
@@ -785,6 +792,7 @@ class EndpointFunctionGenerator:
                     is_raw_client=self._is_raw_client,
                     http_method=method,
                     client_wrapper_member_name=self._client_wrapper_member_name,
+                    request_options_variable_name=request_options_parameter_name,
                 )
 
                 httpx_request = get_httpx_request(
@@ -1966,11 +1974,14 @@ def _get_streaming_response(
 
 
 def is_resumable_sse_endpoint(endpoint: ir_types.HttpEndpoint) -> bool:
+    # A terminator is required: without it a dropped connection cannot be
+    # distinguished from a clean end, so reconnection is never attempted and
+    # emitting the ``_reconnect`` closure would be dead code.
     stream_response = _get_streaming_response(endpoint)
     if stream_response is None:
         return False
     union = stream_response.get_as_union()
-    return union.type == "sse" and union.resumable is True
+    return union.type == "sse" and union.resumable is True and union.terminator is not None
 
 
 def is_overloaded_streaming_method(endpoint: ir_types.HttpEndpoint) -> bool:

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
@@ -19,6 +19,7 @@ from fern_python.generators.pydantic_model.model_utilities import can_tr_be_fern
 from fern_python.generators.sdk.client_generator.constants import (
     CHUNK_VARIABLE,
     RESPONSE_VARIABLE,
+    SSE_RECONNECT_VARIABLE,
 )
 from fern_python.generators.sdk.client_generator.endpoint_metadata_collector import (
     EndpointMetadata,
@@ -696,6 +697,8 @@ class EndpointFunctionGenerator:
                         and endpoint.request_body.get_as_union().type == "fileUpload"
                         else False
                     ),
+                    emit_sse_reconnect=is_resumable_sse_endpoint(endpoint),
+                    reconnect_variable_name=SSE_RECONNECT_VARIABLE,
                 )
 
             if self._endpoint.sdk_request is not None and self._endpoint.sdk_request.stream_parameter is not None:
@@ -1945,6 +1948,29 @@ def is_streaming_endpoint(endpoint: ir_types.HttpEndpoint) -> bool:
             )
         )
     )
+
+
+def _get_streaming_response(
+    endpoint: ir_types.HttpEndpoint,
+) -> Optional[ir_types.StreamingResponse]:
+    if endpoint.response is None or endpoint.response.body is None:
+        return None
+    return endpoint.response.body.visit(
+        json=lambda _: None,
+        file_download=lambda _: None,
+        text=lambda _: None,
+        bytes=lambda _: None,
+        streaming=lambda stream_response: stream_response,
+        stream_parameter=lambda stream_param_response: stream_param_response.stream_response,
+    )
+
+
+def is_resumable_sse_endpoint(endpoint: ir_types.HttpEndpoint) -> bool:
+    stream_response = _get_streaming_response(endpoint)
+    if stream_response is None:
+        return False
+    union = stream_response.get_as_union()
+    return union.type == "sse" and union.resumable is True
 
 
 def is_overloaded_streaming_method(endpoint: ir_types.HttpEndpoint) -> bool:

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -4,7 +4,11 @@ from ..context.sdk_generator_context import SdkGeneratorContext
 from fern_python.codegen import AST
 from fern_python.external_dependencies.json import Json
 from fern_python.external_dependencies.pydantic import Pydantic
-from fern_python.generators.sdk.client_generator.constants import CHUNK_VARIABLE, RESPONSE_VARIABLE
+from fern_python.generators.sdk.client_generator.constants import (
+    CHUNK_VARIABLE,
+    RESPONSE_VARIABLE,
+    SSE_RECONNECT_VARIABLE,
+)
 from fern_python.generators.sdk.client_generator.pagination.abstract_paginator import (
     PaginationSnippetConfig,
 )
@@ -131,6 +135,23 @@ class EndpointResponseCodeWriter:
                         AST.Expression(
                             f'request_options.get("max_stream_reconnection_attempts", self.{self._client_wrapper_member_name}.get_max_stream_reconnection_attempts()) if request_options is not None else self.{self._client_wrapper_member_name}.get_max_stream_reconnection_attempts()'
                         ),
+                    )
+                )
+                # The stream terminator gates reconnection: without it, a
+                # dropped connection is indistinguishable from a clean end.
+                if stream_response_union.terminator is not None:
+                    event_source_kwargs.append(
+                        (
+                            "stream_terminator",
+                            AST.Expression(repr(stream_response_union.terminator)),
+                        )
+                    )
+                # Closure that re-issues the request with a Last-Event-ID header;
+                # emitted alongside the streaming call for resumable endpoints.
+                event_source_kwargs.append(
+                    (
+                        "reconnect",
+                        AST.Expression(SSE_RECONNECT_VARIABLE),
                     )
                 )
             iter_func_body.extend(

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -56,6 +56,7 @@ class EndpointResponseCodeWriter:
         is_raw_client: bool = False,
         http_method: str = "GET",
         client_wrapper_member_name: str = "_client_wrapper",
+        request_options_variable_name: str = "request_options",
     ):
         self._context = context
         self._response = response
@@ -68,6 +69,7 @@ class EndpointResponseCodeWriter:
         self._is_raw_client = is_raw_client
         self._http_method = http_method
         self._client_wrapper_member_name = client_wrapper_member_name
+        self._request_options_variable_name = request_options_variable_name
 
     def get_writer(self) -> AST.CodeWriter:
         def write(writer: AST.NodeWriter) -> None:
@@ -119,13 +121,17 @@ class EndpointResponseCodeWriter:
                 protocol_info=protocol_info,
             )
             event_source_kwargs: list[tuple[str, AST.Expression]] = []
-            if stream_response_union.resumable is True:
+            # The stream terminator gates reconnection: without it, a dropped
+            # connection is indistinguishable from a clean end, so the whole
+            # reconnection machinery (including the ``_reconnect`` closure) is
+            # only emitted when a terminator is configured.
+            if stream_response_union.resumable is True and stream_response_union.terminator is not None:
                 event_source_kwargs.append(("resumable", AST.Expression("True")))
                 event_source_kwargs.append(
                     (
                         "stream_reconnection_enabled",
                         AST.Expression(
-                            f'request_options.get("stream_reconnection_enabled", self.{self._client_wrapper_member_name}.get_stream_reconnection_enabled()) if request_options is not None else self.{self._client_wrapper_member_name}.get_stream_reconnection_enabled()'
+                            f'{self._request_options_variable_name}.get("stream_reconnection_enabled", self.{self._client_wrapper_member_name}.get_stream_reconnection_enabled()) if {self._request_options_variable_name} is not None else self.{self._client_wrapper_member_name}.get_stream_reconnection_enabled()'
                         ),
                     )
                 )
@@ -133,19 +139,16 @@ class EndpointResponseCodeWriter:
                     (
                         "max_stream_reconnection_attempts",
                         AST.Expression(
-                            f'request_options.get("max_stream_reconnection_attempts", self.{self._client_wrapper_member_name}.get_max_stream_reconnection_attempts()) if request_options is not None else self.{self._client_wrapper_member_name}.get_max_stream_reconnection_attempts()'
+                            f'{self._request_options_variable_name}.get("max_stream_reconnection_attempts", self.{self._client_wrapper_member_name}.get_max_stream_reconnection_attempts()) if {self._request_options_variable_name} is not None else self.{self._client_wrapper_member_name}.get_max_stream_reconnection_attempts()'
                         ),
                     )
                 )
-                # The stream terminator gates reconnection: without it, a
-                # dropped connection is indistinguishable from a clean end.
-                if stream_response_union.terminator is not None:
-                    event_source_kwargs.append(
-                        (
-                            "stream_terminator",
-                            AST.Expression(repr(stream_response_union.terminator)),
-                        )
+                event_source_kwargs.append(
+                    (
+                        "stream_terminator",
+                        AST.Expression(repr(stream_response_union.terminator)),
                     )
+                )
                 # Closure that re-issues the request with a Last-Event-ID header;
                 # emitted alongside the streaming call for resumable endpoints.
                 event_source_kwargs.append(
@@ -494,7 +497,7 @@ class EndpointResponseCodeWriter:
         defaulted_chunk_size_default = maybe_chunk_size_default if maybe_chunk_size_default is not None else "None"
         chunk_size_variable = "_chunk_size"
         writer.write_line(
-            f'{chunk_size_variable} = request_options.get("chunk_size", {defaulted_chunk_size_default}) if request_options is not None else {defaulted_chunk_size_default}'
+            f'{chunk_size_variable} = {self._request_options_variable_name}.get("chunk_size", {defaulted_chunk_size_default}) if {self._request_options_variable_name} is not None else {defaulted_chunk_size_default}'
         )
 
         # For raw clients, wrap the generator in an HttpResponse

--- a/generators/python/tests/utils/test_http_sse.py
+++ b/generators/python/tests/utils/test_http_sse.py
@@ -1,10 +1,15 @@
+import asyncio
 import json
-from typing import AsyncIterator
+import threading
+import time
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any, AsyncIterator, Callable, Iterator, List, Optional, Sequence, cast
 from unittest.mock import AsyncMock, Mock
 
 import httpx
 import pytest
 
+import core_utilities.shared.http_sse._api as _sse_api
 from core_utilities.shared.http_sse import (
     MAX_LINE_SIZE,
     EventSource,
@@ -1039,3 +1044,477 @@ class TestMaxLineSize:
         assert events[0].data == "hello"
         assert events[1].event == "pong"
         assert events[1].data == "world"
+
+
+# ---------------------------------------------------------------------------
+# SSE stream reconnection
+# ---------------------------------------------------------------------------
+
+TERMINATOR = "[DONE]"
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``httpx.Response`` that streams predefined chunks."""
+
+    def __init__(self, chunks: List[bytes], content_type: str = "text/event-stream") -> None:
+        self.headers = {"content-type": content_type}
+        self._chunks = chunks
+        self.is_closed = False
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _sse(*events: str) -> _FakeResponse:
+    return _FakeResponse([e.encode("utf-8") for e in events])
+
+
+class _SyncReconnector:
+    """Records reconnect calls and hands out a queue of streams (or ``None``)."""
+
+    def __init__(self, streams: Sequence[Optional[_FakeResponse]]) -> None:
+        self._streams = streams
+        self.calls: List[str] = []
+
+    def __call__(self, last_event_id: str):  # type: ignore[no-untyped-def]
+        index = len(self.calls)
+        self.calls.append(last_event_id)
+        response = self._streams[index] if index < len(self._streams) else None
+
+        @contextmanager
+        def _cm() -> Iterator[Optional[_FakeResponse]]:
+            try:
+                yield response
+            finally:
+                if response is not None:
+                    response.is_closed = True
+
+        return _cm()
+
+
+class _AsyncReconnector:
+    def __init__(self, streams: Sequence[Optional[_FakeResponse]]) -> None:
+        self._streams = streams
+        self.calls: List[str] = []
+
+    def __call__(self, last_event_id: str):  # type: ignore[no-untyped-def]
+        index = len(self.calls)
+        self.calls.append(last_event_id)
+        response = self._streams[index] if index < len(self._streams) else None
+
+        @asynccontextmanager
+        async def _cm() -> AsyncIterator[Optional[_FakeResponse]]:
+            try:
+                yield response
+            finally:
+                if response is not None:
+                    response.is_closed = True
+
+        return _cm()
+
+
+def _collect_sync(event_source: EventSource, terminator: Optional[str] = TERMINATOR) -> List[str]:
+    """Consume like generated SDK code: stop when the terminator event arrives."""
+    data: List[str] = []
+    for sse in event_source.iter_sse():
+        if terminator is not None and sse.data == terminator:
+            break
+        data.append(sse.data)
+    return data
+
+
+async def _collect_async(event_source: EventSource, terminator: Optional[str] = TERMINATOR) -> List[str]:
+    data: List[str] = []
+    async for sse in event_source.aiter_sse():
+        if terminator is not None and sse.data == terminator:
+            break
+        data.append(sse.data)
+    return data
+
+
+@pytest.fixture(autouse=True)
+def _fast_reconnect_delay(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """Shrink the default reconnect backoff so timing-agnostic tests stay fast."""
+    monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 10)
+
+
+def _resumable_source(
+    response: _FakeResponse,
+    reconnect: Optional[Callable[[str], Any]],
+    *,
+    stream_reconnection_enabled: bool = True,
+    max_stream_reconnection_attempts: Optional[int] = None,
+    resumable: bool = True,
+    stream_terminator: Optional[str] = TERMINATOR,
+) -> EventSource:
+    return EventSource(
+        cast(httpx.Response, response),
+        resumable=resumable,
+        stream_reconnection_enabled=stream_reconnection_enabled,
+        max_stream_reconnection_attempts=max_stream_reconnection_attempts,
+        stream_terminator=stream_terminator,
+        reconnect=reconnect,
+    )
+
+
+class TestSSEReconnectionSync:
+    def test_reconnects_with_last_event_id(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n', 'id: 2\ndata: {"value": 2}\n\n')
+        second = _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n")
+        reconnect = _SyncReconnector([second])
+
+        source = _resumable_source(first, reconnect)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        assert reconnect.calls == ["2"]
+
+    def test_reconnects_from_last_dispatched_id_not_parsed_id(self) -> None:
+        # evt-2's id: line is parsed but the stream drops before evt-2's data +
+        # blank line, so evt-2 is never dispatched. Reconnection must resume
+        # from evt-1 or evt-2 would be silently skipped.
+        first = _sse('id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n")
+        second = _sse('id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n")
+        reconnect = _SyncReconnector([second])
+
+        source = _resumable_source(first, reconnect)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}']
+        assert reconnect.calls == ["evt-1"]
+
+    def test_multiple_sequential_reconnects(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        streams = [
+            _sse('id: 2\ndata: {"value": 2}\n\n'),
+            _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"),
+        ]
+        reconnect = _SyncReconnector(streams)
+
+        source = _resumable_source(first, reconnect)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        assert reconnect.calls == ["1", "2"]
+
+    def test_no_terminator_disables_reconnect(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([_sse('id: 2\ndata: {"value": 2}\n\n')])
+
+        source = _resumable_source(first, reconnect, stream_terminator=None)
+        data = _collect_sync(source, terminator=None)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    def test_reconnection_disabled_flag(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect, stream_reconnection_enabled=False)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    def test_not_resumable_disables_reconnect(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect, resumable=False)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    def test_no_reconnect_callback(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        source = _resumable_source(first, None)
+        data = _collect_sync(source)
+        assert data == ['{"value": 1}']
+
+    def test_no_last_id_disables_reconnect(self) -> None:
+        first = _sse('data: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    def test_max_reconnection_attempts_cap(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        # Server is down: every reconnect yields an empty stream.
+        reconnect = _SyncReconnector([_sse(), _sse(), _sse(), _sse(), _sse()])
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=3)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert len(reconnect.calls) == 3
+
+    def test_attempts_reset_on_progress(self) -> None:
+        # max=1, but each reconnect yields an event which resets the counter,
+        # so all events arrive despite the low cap.
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        streams = [
+            _sse('id: 2\ndata: {"value": 2}\n\n'),
+            _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"),
+        ]
+        reconnect = _SyncReconnector(streams)
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=1)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        assert reconnect.calls == ["1", "2"]
+
+    def test_clean_terminator_does_not_reconnect(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n")
+        reconnect = _SyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    def test_null_reconnect_body_counts_as_failed_attempt(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([None, None])
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=2)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert len(reconnect.calls) == 2
+
+
+class TestSSEReconnectionAsync:
+    @pytest.mark.asyncio
+    async def test_reconnects_with_last_event_id(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n', 'id: 2\ndata: {"value": 2}\n\n')
+        second = _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n")
+        reconnect = _AsyncReconnector([second])
+
+        source = _resumable_source(first, reconnect)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        assert reconnect.calls == ["2"]
+
+    @pytest.mark.asyncio
+    async def test_reconnects_from_last_dispatched_id_not_parsed_id(self) -> None:
+        first = _sse('id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n")
+        second = _sse('id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n")
+        reconnect = _AsyncReconnector([second])
+
+        source = _resumable_source(first, reconnect)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}']
+        assert reconnect.calls == ["evt-1"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_sequential_reconnects(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        streams = [
+            _sse('id: 2\ndata: {"value": 2}\n\n'),
+            _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"),
+        ]
+        reconnect = _AsyncReconnector(streams)
+
+        source = _resumable_source(first, reconnect)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        assert reconnect.calls == ["1", "2"]
+
+    @pytest.mark.asyncio
+    async def test_no_terminator_disables_reconnect(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _AsyncReconnector([_sse('id: 2\ndata: {"value": 2}\n\n')])
+
+        source = _resumable_source(first, reconnect, stream_terminator=None)
+        data = await _collect_async(source, terminator=None)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    @pytest.mark.asyncio
+    async def test_reconnection_disabled_flag(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _AsyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect, stream_reconnection_enabled=False)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    @pytest.mark.asyncio
+    async def test_not_resumable_disables_reconnect(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _AsyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect, resumable=False)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    @pytest.mark.asyncio
+    async def test_max_reconnection_attempts_cap(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _AsyncReconnector([_sse(), _sse(), _sse(), _sse(), _sse()])
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=3)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}']
+        assert len(reconnect.calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_attempts_reset_on_progress(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        streams = [
+            _sse('id: 2\ndata: {"value": 2}\n\n'),
+            _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"),
+        ]
+        reconnect = _AsyncReconnector(streams)
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=1)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        assert reconnect.calls == ["1", "2"]
+
+    @pytest.mark.asyncio
+    async def test_clean_terminator_does_not_reconnect(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n")
+        reconnect = _AsyncReconnector([_sse("data: [DONE]\n\n")])
+
+        source = _resumable_source(first, reconnect)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == []
+
+    @pytest.mark.asyncio
+    async def test_null_reconnect_body_counts_as_failed_attempt(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _AsyncReconnector([None, None])
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=2)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}']
+        assert len(reconnect.calls) == 2
+
+
+class TestSSEReconnectionBackoff:
+    def test_default_delay_when_no_retry(self) -> None:
+        source = EventSource(cast(httpx.Response, _sse()), resumable=True, stream_terminator=TERMINATOR)
+        # Reads the module default (not the shrunk test value) via a fresh source.
+        assert source._reconnect_delay_seconds(None) == _sse_api.DEFAULT_RECONNECT_DELAY_MS / 1000.0
+
+    def test_zero_retry_falls_back_to_default(self) -> None:
+        source = EventSource(cast(httpx.Response, _sse()), resumable=True, stream_terminator=TERMINATOR)
+        assert source._reconnect_delay_seconds(0) == _sse_api.DEFAULT_RECONNECT_DELAY_MS / 1000.0
+
+    def test_server_retry_directive_respected(self) -> None:
+        source = EventSource(cast(httpx.Response, _sse()), resumable=True, stream_terminator=TERMINATOR)
+        assert source._reconnect_delay_seconds(250) == 0.25
+
+    def test_server_retry_clamped_to_max(self) -> None:
+        source = EventSource(cast(httpx.Response, _sse()), resumable=True, stream_terminator=TERMINATOR)
+        assert source._reconnect_delay_seconds(120_000) == _sse_api.MAX_RECONNECT_DELAY_MS / 1000.0
+
+    def test_backoff_elapses_between_reconnects(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 120)
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        streams = [
+            _sse('id: 2\ndata: {"value": 2}\n\n'),
+            _sse('id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"),
+        ]
+        reconnect = _SyncReconnector(streams)
+        source = _resumable_source(first, reconnect)
+
+        start = time.monotonic()
+        data = _collect_sync(source)
+        elapsed = time.monotonic() - start
+
+        assert data == ['{"value": 1}', '{"value": 2}', '{"value": 3}']
+        # Two reconnects at ~120ms each.
+        assert elapsed >= 0.2
+
+    def test_server_retry_used_instead_of_default(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        # Large default; server retry of 30ms should win, so the reconnect
+        # happens quickly rather than after the default.
+        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 5_000)
+        first = _sse('retry: 30\nid: 1\ndata: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([_sse('id: 2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n")])
+        source = _resumable_source(first, reconnect)
+
+        start = time.monotonic()
+        data = _collect_sync(source)
+        elapsed = time.monotonic() - start
+
+        assert data == ['{"value": 1}', '{"value": 2}']
+        assert reconnect.calls == ["1"]
+        assert elapsed < 1.0
+
+
+class TestSSEReconnectionCancellation:
+    def test_sync_cancellation_during_backoff(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 2_000)
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _SyncReconnector([_sse("data: [DONE]\n\n")])
+        source = _resumable_source(first, reconnect)
+
+        # Simulate the consumer cancelling: close the underlying response while
+        # the stream is waiting out its (long) reconnect backoff.
+        timer = threading.Timer(0.05, lambda: setattr(first, "is_closed", True))
+        timer.start()
+        try:
+            start = time.monotonic()
+            data = _collect_sync(source)
+            elapsed = time.monotonic() - start
+        finally:
+            timer.cancel()
+
+        assert data == ['{"value": 1}']
+        # Aborted promptly, well before the 2s backoff, and no reconnect issued.
+        assert elapsed < 1.0
+        assert reconnect.calls == []
+
+    @pytest.mark.asyncio
+    async def test_async_cancellation_during_backoff(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 2_000)
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        reconnect = _AsyncReconnector([_sse("data: [DONE]\n\n")])
+        source = _resumable_source(first, reconnect)
+
+        collected: List[str] = []
+
+        async def _consume() -> None:
+            async for sse in source.aiter_sse():
+                if sse.data == TERMINATOR:
+                    break
+                collected.append(sse.data)
+
+        task = asyncio.ensure_future(_consume())
+        # Let the first event flush, then cancel while it is in reconnect backoff.
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert collected == ['{"value": 1}']
+        assert reconnect.calls == []

--- a/generators/python/tests/utils/test_http_sse.py
+++ b/generators/python/tests/utils/test_http_sse.py
@@ -1598,6 +1598,32 @@ class TestSSEReconnectionRobustness:
         assert data == ['{"value": 1}', '{"value": 2}']
         assert reconnect.calls == ["1", "1"]
 
+    def test_sync_exhaustion_ends_cleanly_regardless_of_failure_shape(self) -> None:
+        # Once the reconnect budget is exhausted, a resumable stream must end
+        # cleanly whether the final attempt failed via an empty body or a live
+        # mid-read drop — give-up should not depend on the failure's shape.
+        first = _RaisingResponse([b"id: 1\ndata: {\"value\": 1}\n\n"])
+        # The one allowed reconnect also drops mid-read (a live transport error),
+        # dispatching nothing, so the attempt cap (1) is reached.
+        reconnect = _SyncReconnector([_RaisingResponse([])])
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=1)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_async_exhaustion_ends_cleanly_regardless_of_failure_shape(self) -> None:
+        first = _RaisingResponse([b"id: 1\ndata: {\"value\": 1}\n\n"])
+        reconnect = _AsyncReconnector([_RaisingResponse([])])
+
+        source = _resumable_source(first, reconnect, max_stream_reconnection_attempts=1)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}']
+        assert reconnect.calls == ["1"]
+
 
 # ---------------------------------------------------------------------------
 # End-to-end reconnection over a real HTTP socket

--- a/generators/python/tests/utils/test_http_sse.py
+++ b/generators/python/tests/utils/test_http_sse.py
@@ -3,6 +3,7 @@ import json
 import threading
 import time
 from contextlib import asynccontextmanager, contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, AsyncIterator, Callable, Iterator, List, Optional, Sequence, cast
 from unittest.mock import AsyncMock, Mock
 
@@ -1059,7 +1060,6 @@ class _FakeResponse:
     def __init__(self, chunks: List[bytes], content_type: str = "text/event-stream") -> None:
         self.headers = {"content-type": content_type}
         self._chunks = chunks
-        self.is_closed = False
 
     def iter_bytes(self) -> Iterator[bytes]:
         for chunk in self._chunks:
@@ -1088,11 +1088,7 @@ class _SyncReconnector:
 
         @contextmanager
         def _cm() -> Iterator[Optional[_FakeResponse]]:
-            try:
-                yield response
-            finally:
-                if response is not None:
-                    response.is_closed = True
+            yield response
 
         return _cm()
 
@@ -1109,11 +1105,7 @@ class _AsyncReconnector:
 
         @asynccontextmanager
         async def _cm() -> AsyncIterator[Optional[_FakeResponse]]:
-            try:
-                yield response
-            finally:
-                if response is not None:
-                    response.is_closed = True
+            yield response
 
         return _cm()
 
@@ -1472,26 +1464,27 @@ class TestSSEReconnectionBackoff:
 
 
 class TestSSEReconnectionCancellation:
-    def test_sync_cancellation_during_backoff(self, monkeypatch: "pytest.MonkeyPatch") -> None:
-        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 2_000)
+    def test_sync_backoff_is_interruptible(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        # A sync consumer blocks inside ``next()`` during the backoff, so the
+        # realistic interruption is a signal (e.g. Ctrl-C) raised out of
+        # ``time.sleep``. It must propagate and abort the reconnect rather than
+        # being swallowed, and no further request may be issued.
         first = _sse('id: 1\ndata: {"value": 1}\n\n')
         reconnect = _SyncReconnector([_sse("data: [DONE]\n\n")])
         source = _resumable_source(first, reconnect)
 
-        # Simulate the consumer cancelling: close the underlying response while
-        # the stream is waiting out its (long) reconnect backoff.
-        timer = threading.Timer(0.05, lambda: setattr(first, "is_closed", True))
-        timer.start()
-        try:
-            start = time.monotonic()
-            data = _collect_sync(source)
-            elapsed = time.monotonic() - start
-        finally:
-            timer.cancel()
+        def _interrupt(_self: EventSource, _last_retry: Optional[int]) -> None:
+            raise KeyboardInterrupt
 
-        assert data == ['{"value": 1}']
-        # Aborted promptly, well before the 2s backoff, and no reconnect issued.
-        assert elapsed < 1.0
+        monkeypatch.setattr(_sse_api.EventSource, "_sleep_before_reconnect", _interrupt)
+
+        collected: List[str] = []
+        with pytest.raises(KeyboardInterrupt):
+            for sse in source.iter_sse():
+                collected.append(sse.data)
+
+        assert collected == ['{"value": 1}']
+        # Interrupted during the backoff, before any reconnect was issued.
         assert reconnect.calls == []
 
     @pytest.mark.asyncio
@@ -1518,3 +1511,108 @@ class TestSSEReconnectionCancellation:
 
         assert collected == ['{"value": 1}']
         assert reconnect.calls == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end reconnection over a real HTTP socket
+# ---------------------------------------------------------------------------
+#
+# Unit tests above drive ``EventSource`` with in-memory fakes. These exercise
+# the full stack against a real ``httpx.Client``/``AsyncClient`` and a real
+# local HTTP server that deliberately drops the connection mid-stream, so the
+# client must transparently reconnect using the ``Last-Event-ID`` header — the
+# same code path a generated SDK runs. This is the setup that surfaced a bug the
+# in-memory fakes could not: a fully-consumed real stream reports
+# ``is_closed=True``, which must NOT be mistaken for consumer cancellation.
+
+_E2E_TERMINATOR = "[DONE]"
+_E2E_FINAL_ID = 5
+
+
+class _DroppingSSEHandler(BaseHTTPRequestHandler):
+    """Streams events 1..5 but drops the connection after every 2 events.
+
+    On the first connection it sends ``id: 3`` (parsed) *without* its
+    terminating blank line before dropping, so a correct client must resume
+    from the last *dispatched* id (2), never the parsed-but-undispatched 3.
+    """
+
+    # Records the ``Last-Event-ID`` header seen on each request, in order.
+    last_event_ids: List[Optional[str]] = []
+
+    def log_message(self, *args: Any) -> None:  # silence noisy default logging
+        pass
+
+    def do_POST(self) -> None:
+        last_event_id = self.headers.get("Last-Event-ID")
+        type(self).last_event_ids.append(last_event_id)
+        start = int(last_event_id) if last_event_id else 0
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+
+        sent_this_conn = 0
+        event_id = start + 1
+        while event_id <= _E2E_FINAL_ID:
+            if start == 0 and event_id == 3 and sent_this_conn == 2:
+                # id: 3 parsed but never dispatched, then drop.
+                self.wfile.write(b"id: 3\n")
+                self.wfile.flush()
+                return
+            self.wfile.write(f"id: {event_id}\ndata: event-{event_id}\n\n".encode())
+            self.wfile.flush()
+            sent_this_conn += 1
+            event_id += 1
+            if sent_this_conn >= 2 and event_id <= _E2E_FINAL_ID:
+                return  # abrupt drop, no terminator -> client must reconnect
+        self.wfile.write(f"data: {_E2E_TERMINATOR}\n\n".encode())
+        self.wfile.flush()
+
+
+@contextmanager
+def _running_sse_server() -> Iterator[str]:
+    _DroppingSSEHandler.last_event_ids = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _DroppingSSEHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestSSEReconnectionEndToEnd:
+    def test_sync_reconnects_over_real_socket(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 10)
+        with _running_sse_server() as base_url, httpx.Client() as client:
+
+            def _reconnect(last_event_id: str):  # type: ignore[no-untyped-def]
+                return client.stream("POST", base_url, headers={"Last-Event-ID": last_event_id})
+
+            collected: List[str] = []
+            with client.stream("POST", base_url) as response:
+                source = _resumable_source(cast(Any, response), _reconnect, stream_terminator=_E2E_TERMINATOR)
+                collected = _collect_sync(source, terminator=_E2E_TERMINATOR)
+
+        assert collected == ["event-1", "event-2", "event-3", "event-4", "event-5"]
+        # Resumed from the last *dispatched* id (2), not the parsed id (3).
+        assert _DroppingSSEHandler.last_event_ids == [None, "2", "4"]
+
+    @pytest.mark.asyncio
+    async def test_async_reconnects_over_real_socket(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        monkeypatch.setattr(_sse_api, "DEFAULT_RECONNECT_DELAY_MS", 10)
+        with _running_sse_server() as base_url:
+            async with httpx.AsyncClient() as client:
+
+                def _reconnect(last_event_id: str):  # type: ignore[no-untyped-def]
+                    return client.stream("POST", base_url, headers={"Last-Event-ID": last_event_id})
+
+                collected: List[str] = []
+                async with client.stream("POST", base_url) as response:
+                    source = _resumable_source(cast(Any, response), _reconnect, stream_terminator=_E2E_TERMINATOR)
+                    collected = await _collect_async(source, terminator=_E2E_TERMINATOR)
+
+        assert collected == ["event-1", "event-2", "event-3", "event-4", "event-5"]
+        assert _DroppingSSEHandler.last_event_ids == [None, "2", "4"]

--- a/generators/python/tests/utils/test_http_sse.py
+++ b/generators/python/tests/utils/test_http_sse.py
@@ -1057,8 +1057,11 @@ TERMINATOR = "[DONE]"
 class _FakeResponse:
     """Minimal stand-in for ``httpx.Response`` that streams predefined chunks."""
 
-    def __init__(self, chunks: List[bytes], content_type: str = "text/event-stream") -> None:
+    def __init__(
+        self, chunks: List[bytes], content_type: str = "text/event-stream", status_code: int = 200
+    ) -> None:
         self.headers = {"content-type": content_type}
+        self.status_code = status_code
         self._chunks = chunks
 
     def iter_bytes(self) -> Iterator[bytes]:
@@ -1511,6 +1514,89 @@ class TestSSEReconnectionCancellation:
 
         assert collected == ['{"value": 1}']
         assert reconnect.calls == []
+
+
+class _RaisingResponse(_FakeResponse):
+    """Streams some chunks, then raises a transport error mid-read (a drop)."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        super().__init__(chunks)
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+        raise httpx.ReadError("connection dropped")
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+        raise httpx.ReadError("connection dropped")
+
+
+class TestSSEReconnectionRobustness:
+    def test_sync_transport_error_propagates_when_not_resumable(self) -> None:
+        # A mid-stream drop on a non-resumable stream must surface to the caller
+        # (as it did before reconnection existed), not look like a clean end.
+        response = _RaisingResponse([b'data: {"value": 1}\n\n'])
+        source = _resumable_source(response, None, resumable=False)
+
+        collected: List[str] = []
+        with pytest.raises(httpx.ReadError):
+            for sse in source.iter_sse():
+                collected.append(sse.data)
+
+        assert collected == ['{"value": 1}']
+
+    @pytest.mark.asyncio
+    async def test_async_transport_error_propagates_when_not_resumable(self) -> None:
+        response = _RaisingResponse([b'data: {"value": 1}\n\n'])
+        source = _resumable_source(response, None, resumable=False)
+
+        collected: List[str] = []
+        with pytest.raises(httpx.ReadError):
+            async for sse in source.aiter_sse():
+                collected.append(sse.data)
+
+        assert collected == ['{"value": 1}']
+
+    def test_sync_transport_error_triggers_reconnect_when_resumable(self) -> None:
+        # The same drop on a resumable stream reconnects instead of raising.
+        first = _RaisingResponse([b"id: 1\ndata: {\"value\": 1}\n\n"])
+        reconnect = _SyncReconnector([_sse('id: 2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n")])
+        source = _resumable_source(first, reconnect)
+
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}']
+        assert reconnect.calls == ["1"]
+
+    def test_reconnect_error_status_is_failed_attempt(self) -> None:
+        # A resume that returns a non-SSE error body (e.g. 500) must be treated
+        # as a failed attempt (back off, retry), not parsed as an SSE stream.
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        error = _FakeResponse([b"<html>error</html>"], content_type="text/html", status_code=500)
+        good = _sse('id: 2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n")
+        reconnect = _SyncReconnector([error, good])
+
+        source = _resumable_source(first, reconnect)
+        data = _collect_sync(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}']
+        # Two attempts: the error response, then the successful resume.
+        assert reconnect.calls == ["1", "1"]
+
+    @pytest.mark.asyncio
+    async def test_async_reconnect_error_status_is_failed_attempt(self) -> None:
+        first = _sse('id: 1\ndata: {"value": 1}\n\n')
+        error = _FakeResponse([b"<html>error</html>"], content_type="text/html", status_code=500)
+        good = _sse('id: 2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n")
+        reconnect = _AsyncReconnector([error, good])
+
+        source = _resumable_source(first, reconnect)
+        data = await _collect_async(source)
+
+        assert data == ['{"value": 1}', '{"value": 2}']
+        assert reconnect.calls == ["1", "1"]
 
 
 # ---------------------------------------------------------------------------

--- a/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/accept-header/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/alias/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/alias/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/alias/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/any-auth/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/audiences/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/basic-auth/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/bytes-download/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/circular-references-advanced/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/client-side-params/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/content-type/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/empty-clients/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/error-property/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/errors/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/errors/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/errors/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/examples/readme/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extends/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/extends/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/extends/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/extra-properties/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/folders/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/folders/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/folders/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/header-auth/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/http-head/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/imdb/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/license/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/license/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/license/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/license/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/license/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/license/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/license/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/license/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/license/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/license/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/literals-unions/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/mixed-case/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/no-content-response/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/no-environment/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/no-retries/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/null-type/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/object/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/object/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/object/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/object/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/object/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/object/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/optional/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/optional/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/optional/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/package-yml/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/path-parameters/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/plain-text/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/property-access/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/public-object/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/request-parameters/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/required-nullable/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/response-property/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/completions/raw_client.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/completions/raw_client.py
@@ -49,6 +49,18 @@ class RawCompletionsClient:
             omit=OMIT,
         ) as _response:
 
+            def _reconnect(last_event_id: str):
+                return self._client_wrapper.httpx_client.stream(
+                    "stream",
+                    method="POST",
+                    json={
+                        "query": query,
+                    },
+                    headers={"Last-Event-ID": last_event_id},
+                    request_options=request_options,
+                    omit=OMIT,
+                )
+
             def _stream() -> HttpResponse[typing.Iterator[StreamedCompletion]]:
                 try:
                     if 200 <= _response.status_code < 300:
@@ -69,6 +81,8 @@ class RawCompletionsClient:
                                 )
                                 if request_options is not None
                                 else self._client_wrapper.get_max_stream_reconnection_attempts(),
+                                stream_terminator="[[DONE]]",
+                                reconnect=_reconnect,
                             )
                             for _sse in _event_source.iter_sse():
                                 if _sse.data == "[[DONE]]":
@@ -215,6 +229,18 @@ class AsyncRawCompletionsClient:
             omit=OMIT,
         ) as _response:
 
+            def _reconnect(last_event_id: str):
+                return self._client_wrapper.httpx_client.stream(
+                    "stream",
+                    method="POST",
+                    json={
+                        "query": query,
+                    },
+                    headers={"Last-Event-ID": last_event_id},
+                    request_options=request_options,
+                    omit=OMIT,
+                )
+
             async def _stream() -> AsyncHttpResponse[typing.AsyncIterator[StreamedCompletion]]:
                 try:
                     if 200 <= _response.status_code < 300:
@@ -235,6 +261,8 @@ class AsyncRawCompletionsClient:
                                 )
                                 if request_options is not None
                                 else self._client_wrapper.get_max_stream_reconnection_attempts(),
+                                stream_terminator="[[DONE]]",
+                                reconnect=_reconnect,
                             )
                             async for _sse in _event_source.aiter_sse():
                                 if _sse.data == "[[DONE]]":

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/simple-api/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/trace/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/trace/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/trace/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/unknown/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/variables/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/variables/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/variables/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/version-no-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/version/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/version/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/version/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/version/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/webhooks/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 

--- a/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
@@ -113,24 +113,38 @@ class EventSource:
     def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
         return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
+    def _reconnect_applicable(self) -> bool:
+        """Whether reconnection is configured for this stream at all.
+
+        This is the terminator-gating half of the reconnect decision, kept
+        separate from :meth:`_should_reconnect` (which additionally requires a
+        last *dispatched* id and an unexhausted attempt budget). The split lets
+        a mid-stream transport error terminate consistently:
+        - a stream that can never reconnect (non-resumable, no terminator,
+          disabled, or no callback) must re-raise the error to the caller, so a
+          truncated stream is not mistaken for a clean completion;
+        - a resumable stream that has merely run out of attempts (or has no id
+          to resume from) ends cleanly — the same way an exhausted empty/error
+          -body resume already does, matching the TypeScript ``return``.
+        """
+        return (
+            self._resumable
+            and self._stream_terminator is not None
+            and self._stream_reconnection_enabled
+            and self._reconnect is not None
+        )
+
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
 
         Mirrors the TypeScript ``shouldReconnect`` gating:
-        - only resumable SSE endpoints reconnect;
-        - a stream terminator must be configured, otherwise we cannot tell a
-          clean completion from a dropped connection and must not reconnect;
-        - reconnection must be enabled and a reconnect callback provided;
+        - only resumable SSE endpoints with a configured terminator, reconnect
+          enabled, and a reconnect callback are eligible (see
+          :meth:`_reconnect_applicable`);
         - a last *dispatched* event id must exist to resume from;
         - the consecutive-failed-attempt cap must not be exceeded.
         """
-        if not self._resumable:
-            return False
-        if self._stream_terminator is None:
-            return False
-        if not self._stream_reconnection_enabled:
-            return False
-        if self._reconnect is None:
+        if not self._reconnect_applicable():
             return False
         if not last_dispatched_id:
             return False
@@ -278,13 +292,17 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
                             # ``next`` is used rather than ``for`` so this cannot
                             # swallow a ``GeneratorExit`` raised at a ``yield``.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -360,11 +378,15 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end. Only swallow it when this stream
-                            # is actually going to reconnect; otherwise re-raise so
-                            # a non-resumable stream still surfaces the error to the
+                            # is a premature end. Only swallow it when reconnection
+                            # is configured for this stream; otherwise re-raise so a
+                            # non-resumable stream still surfaces the error to the
                             # caller instead of looking like a clean completion.
-                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                            # When reconnection is applicable but the attempt budget
+                            # is exhausted, we ``break`` and end cleanly below — the
+                            # same way an exhausted empty/error-body resume does, so
+                            # give-up is consistent regardless of failure shape.
+                            if not self._reconnect_applicable():
                                 raise
                             break
                         yield sse
@@ -401,7 +423,11 @@ class EventSource:
                 text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
-                await owned_cm.__aexit__(None, None, None)
+                # Shield the close so a cancellation delivered while reading a
+                # reconnected response still fully tears the connection down
+                # instead of leaking it until the client is closed.
+                with anyio.CancelScope(shield=True):
+                    await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
@@ -28,11 +28,6 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
-# Granularity used to poll for cancellation while waiting out the reconnect
-# backoff. Keeps the delay responsive to cancellation instead of blocking for
-# the whole interval in a single, uninterruptible sleep.
-_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
-
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
@@ -145,43 +140,17 @@ class EventSource:
         base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
         return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
 
-    def _is_cancelled(self) -> bool:
-        """Best-effort check that consumption has been cancelled.
-
-        When the underlying response has been closed there is no point issuing
-        another request, so the backoff delay bails out early.
-        """
-        try:
-            return bool(self._response.is_closed)
-        except Exception:
-            return False
-
     def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            # Re-check cancellation between short sleeps so a consumer that stops
-            # the stream mid-delay is not forced to wait out the whole interval.
-            if self._is_cancelled():
-                return
-            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``time.sleep`` blocks the calling thread but remains interruptible by
+        # signals (e.g. ``KeyboardInterrupt``), which propagate out and abort
+        # the reconnect without issuing another request.
+        time.sleep(self._reconnect_delay_seconds(last_retry))
 
     async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
-        delay = self._reconnect_delay_seconds(last_retry)
-        deadline = time.monotonic() + delay
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            if self._is_cancelled():
-                return
-            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
-            # task (or closes the async generator) mid-delay, this raises and no
-            # further request is issued.
-            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+        # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the task
+        # or closes the async generator mid-delay, this raises (and no further
+        # request is issued) instead of blocking for the whole interval.
+        await anyio.sleep(self._reconnect_delay_seconds(last_retry))
 
     def _decode_response(
         self,
@@ -281,7 +250,26 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    for sse in self._decode_response(response, decoder, text_decoder):
+                    events = self._decode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = next(events)
+                        except StopIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it. ``next`` is used rather than
+                            # ``for`` so this cannot swallow a ``GeneratorExit``
+                            # raised at a ``yield``.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -294,8 +282,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 self._sleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 # Close the previously-opened reconnect response before opening
                 # a new one so we never hold more than one extra connection.
@@ -341,7 +327,24 @@ class EventSource:
         try:
             while True:
                 if response is not None:
-                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                    events = self._adecode_response(response, decoder, text_decoder)
+                    while True:
+                        try:
+                            sse = await events.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except SSEError:
+                            # A protocol violation (e.g. an oversized line) is a
+                            # genuine error, not a dropped connection; propagate it.
+                            # Listed first because ``SSEError`` subclasses
+                            # ``httpx.TransportError``.
+                            raise
+                        except httpx.TransportError:
+                            # A transport error mid-stream (e.g. the server dropped
+                            # the connection: ``ReadError``/``RemoteProtocolError``)
+                            # is a premature end: stop reading and let the reconnect
+                            # decision below handle it.
+                            break
                         yield sse
                         if sse.id:
                             last_dispatched_id = sse.id
@@ -354,8 +357,6 @@ class EventSource:
                 reconnect_attempts += 1
 
                 await self._asleep_before_reconnect(last_retry)
-                if self._is_cancelled():
-                    return
 
                 if owned_cm is not None:
                     await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
@@ -28,14 +28,11 @@ DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
 DEFAULT_RECONNECT_DELAY_MS: int = 1_000
 MAX_RECONNECT_DELAY_MS: int = 30_000
 
+
 # A reconnect callback re-issues the original request (with a ``Last-Event-ID``
 # header set to the supplied event id) and returns a *context manager* yielding
 # a fresh streaming ``httpx.Response``. Sync clients supply a sync context
 # manager; async clients supply an async one.
-SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
-AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
-
-
 class EventSource:
     def __init__(
         self,
@@ -54,16 +51,32 @@ class EventSource:
         self._stream_terminator = stream_terminator
         self._reconnect = reconnect
 
+    @staticmethod
+    def _is_event_stream(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "").partition(";")[0]
+        return "text/event-stream" in content_type
+
     def _check_content_type(self) -> None:
-        content_type = self._response.headers.get("content-type", "").partition(";")[0]
-        if "text/event-stream" not in content_type:
+        if not self._is_event_stream(self._response):
+            content_type = self._response.headers.get("content-type", "").partition(";")[0]
             raise SSEError(
                 f"Expected response header Content-Type to contain 'text/event-stream', got {content_type!r}"
             )
 
-    def _get_charset(self) -> str:
+    def _is_reconnect_response_usable(self, response: httpx.Response) -> bool:
+        """Whether a reconnected response can be resumed as an SSE stream.
+
+        ``httpx.stream`` does not raise on non-success status, so a resume that
+        returns an error page (e.g. ``200 text/html`` or a ``500`` body) would
+        otherwise be parsed as SSE and yield garbage/zero events. Such a
+        response is treated as a failed attempt (back off and retry) instead.
+        """
+        return response.status_code < 400 and self._is_event_stream(response)
+
+    def _get_charset(self, response: Optional[httpx.Response] = None) -> str:
         """Extract charset from Content-Type header, fallback to UTF-8."""
-        content_type = self._response.headers.get("content-type", "")
+        resolved = response if response is not None else self._response
+        content_type = resolved.headers.get("content-type", "")
 
         # Parse charset parameter using regex
         charset_match = re.search(r"charset=([^;\s]+)", content_type, re.IGNORECASE)
@@ -97,8 +110,8 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
-        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
+    def _new_text_decoder(self, response: Optional[httpx.Response] = None) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset(response))(errors="replace")
 
     def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
         """Decide whether a prematurely-ended stream should be reconnected.
@@ -265,10 +278,14 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it. ``next`` is used rather than
-                            # ``for`` so this cannot swallow a ``GeneratorExit``
-                            # raised at a ``yield``.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            # ``next`` is used rather than ``for`` so this cannot
+                            # swallow a ``GeneratorExit`` raised at a ``yield``.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -298,8 +315,9 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
-                    # Null/empty reconnect body: treat as a failed attempt.
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
+                    # Null/empty body or a non-SSE/error response (e.g. 204/304,
+                    # a 500, or an HTML error page): treat as a failed attempt.
                     response = None
                     continue
 
@@ -308,7 +326,7 @@ class EventSource:
                 # keep the last event id (per the SSE spec) and start a fresh
                 # incremental text decoder for the new connection.
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 owned_cm.__exit__(None, None, None)
@@ -342,8 +360,12 @@ class EventSource:
                         except httpx.TransportError:
                             # A transport error mid-stream (e.g. the server dropped
                             # the connection: ``ReadError``/``RemoteProtocolError``)
-                            # is a premature end: stop reading and let the reconnect
-                            # decision below handle it.
+                            # is a premature end. Only swallow it when this stream
+                            # is actually going to reconnect; otherwise re-raise so
+                            # a non-resumable stream still surfaces the error to the
+                            # caller instead of looking like a clean completion.
+                            if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                                raise
                             break
                         yield sse
                         if sse.id:
@@ -370,13 +392,13 @@ class EventSource:
                     response = None
                     continue
                 owned_cm = cm
-                if new_response is None:
+                if new_response is None or not self._is_reconnect_response_usable(new_response):
                     response = None
                     continue
 
                 response = new_response
                 decoder.reset_in_progress_event()
-                text_decoder = self._new_text_decoder()
+                text_decoder = self._new_text_decoder(new_response)
         finally:
             if owned_cm is not None:
                 await owned_cm.__aexit__(None, None, None)

--- a/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
+++ b/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_api.py
@@ -2,15 +2,43 @@
 
 import codecs
 import re
+import time
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, AsyncIterator, Iterator, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    ContextManager,
+    Iterator,
+    Optional,
+)
 
+import anyio
 import httpx
 from ._decoders import SSEDecoder
 from ._exceptions import SSEError
 from ._models import ServerSentEvent
 
 MAX_LINE_SIZE: int = 1_048_576  # 1 MiB
+
+# Reconnection defaults, mirroring the TypeScript SDK's Stream implementation.
+DEFAULT_MAX_RECONNECTION_ATTEMPTS: int = 5
+DEFAULT_RECONNECT_DELAY_MS: int = 1_000
+MAX_RECONNECT_DELAY_MS: int = 30_000
+
+# Granularity used to poll for cancellation while waiting out the reconnect
+# backoff. Keeps the delay responsive to cancellation instead of blocking for
+# the whole interval in a single, uninterruptible sleep.
+_RECONNECT_DELAY_POLL_SECONDS: float = 0.05
+
+# A reconnect callback re-issues the original request (with a ``Last-Event-ID``
+# header set to the supplied event id) and returns a *context manager* yielding
+# a fresh streaming ``httpx.Response``. Sync clients supply a sync context
+# manager; async clients supply an async one.
+SyncReconnect = Callable[[str], ContextManager[httpx.Response]]
+AsyncReconnect = Callable[[str], AsyncContextManager[httpx.Response]]
 
 
 class EventSource:
@@ -21,11 +49,15 @@ class EventSource:
         resumable: bool = False,
         stream_reconnection_enabled: bool = True,
         max_stream_reconnection_attempts: Optional[int] = None,
+        stream_terminator: Optional[str] = None,
+        reconnect: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._response = response
         self._resumable = resumable
         self._stream_reconnection_enabled = stream_reconnection_enabled
         self._max_stream_reconnection_attempts = max_stream_reconnection_attempts
+        self._stream_terminator = stream_terminator
+        self._reconnect = reconnect
 
     def _check_content_type(self) -> None:
         content_type = self._response.headers.get("content-type", "").partition(";")[0]
@@ -70,14 +102,95 @@ class EventSource:
             return buf[:-1].replace("\r", "\n") + "\r"
         return buf.replace("\r", "\n")
 
-    def iter_sse(self) -> Iterator[ServerSentEvent]:
-        self._check_content_type()
-        decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+    def _new_text_decoder(self) -> "codecs.IncrementalDecoder":
+        return codecs.getincrementaldecoder(self._get_charset())(errors="replace")
 
+    def _should_reconnect(self, last_dispatched_id: Optional[str], reconnect_attempts: int) -> bool:
+        """Decide whether a prematurely-ended stream should be reconnected.
+
+        Mirrors the TypeScript ``shouldReconnect`` gating:
+        - only resumable SSE endpoints reconnect;
+        - a stream terminator must be configured, otherwise we cannot tell a
+          clean completion from a dropped connection and must not reconnect;
+        - reconnection must be enabled and a reconnect callback provided;
+        - a last *dispatched* event id must exist to resume from;
+        - the consecutive-failed-attempt cap must not be exceeded.
+        """
+        if not self._resumable:
+            return False
+        if self._stream_terminator is None:
+            return False
+        if not self._stream_reconnection_enabled:
+            return False
+        if self._reconnect is None:
+            return False
+        if not last_dispatched_id:
+            return False
+        max_attempts = (
+            self._max_stream_reconnection_attempts
+            if self._max_stream_reconnection_attempts is not None
+            else DEFAULT_MAX_RECONNECTION_ATTEMPTS
+        )
+        if reconnect_attempts >= max_attempts:
+            return False
+        return True
+
+    def _reconnect_delay_seconds(self, last_retry: Optional[int]) -> float:
+        """Backoff before a reconnect.
+
+        Uses the server's most recent ``retry:`` directive (milliseconds) when
+        present, otherwise a default of ``DEFAULT_RECONNECT_DELAY_MS``, clamped
+        to ``MAX_RECONNECT_DELAY_MS``.
+        """
+        base_ms = last_retry if (last_retry is not None and last_retry > 0) else DEFAULT_RECONNECT_DELAY_MS
+        return min(base_ms, MAX_RECONNECT_DELAY_MS) / 1000.0
+
+    def _is_cancelled(self) -> bool:
+        """Best-effort check that consumption has been cancelled.
+
+        When the underlying response has been closed there is no point issuing
+        another request, so the backoff delay bails out early.
+        """
+        try:
+            return bool(self._response.is_closed)
+        except Exception:
+            return False
+
+    def _sleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            # Re-check cancellation between short sleeps so a consumer that stops
+            # the stream mid-delay is not forced to wait out the whole interval.
+            if self._is_cancelled():
+                return
+            time.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    async def _asleep_before_reconnect(self, last_retry: Optional[int]) -> None:
+        delay = self._reconnect_delay_seconds(last_retry)
+        deadline = time.monotonic() + delay
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            if self._is_cancelled():
+                return
+            # ``anyio.sleep`` is cancellation-aware: if the consumer cancels the
+            # task (or closes the async generator) mid-delay, this raises and no
+            # further request is issued.
+            await anyio.sleep(min(remaining, _RECONNECT_DELAY_POLL_SECONDS))
+
+    def _decode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         buf = ""
-        for chunk in self._response.iter_bytes():
+        for chunk in response.iter_bytes():
             buf += text_decoder.decode(chunk)
             buf = self._normalize_sse_line_endings(buf)
 
@@ -92,6 +205,39 @@ class EventSource:
                     f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
                 )
 
+        yield from self._flush_decoder(buf, decoder, text_decoder)
+
+    async def _adecode_response(
+        self,
+        response: httpx.Response,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> AsyncGenerator[ServerSentEvent, None]:
+        buf = ""
+        async for chunk in response.aiter_bytes():
+            buf += text_decoder.decode(chunk)
+            buf = self._normalize_sse_line_endings(buf)
+
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                sse = decoder.decode(line)
+                if sse is not None:
+                    yield sse
+
+            if len(buf) > MAX_LINE_SIZE:
+                raise SSEError(
+                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
+                )
+
+        for sse in self._flush_decoder(buf, decoder, text_decoder):
+            yield sse
+
+    def _flush_decoder(
+        self,
+        buf: str,
+        decoder: SSEDecoder,
+        text_decoder: "codecs.IncrementalDecoder",
+    ) -> Iterator[ServerSentEvent]:
         # Flush any remaining bytes from the incremental decoder
         buf += text_decoder.decode(b"", final=True)
         buf = buf.replace("\r\n", "\n").replace("\r", "\n")
@@ -111,48 +257,128 @@ class EventSource:
             sse = decoder.decode(buf)
             if sse is not None:
                 yield sse
+
+    def iter_sse(self) -> Iterator[ServerSentEvent]:
+        self._check_content_type()
+        decoder = SSEDecoder()
+        text_decoder = self._new_text_decoder()
+
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        # Consecutive failed reconnection attempts. Reset to 0 whenever an event
+        # is successfully dispatched (reset-on-progress) — matching browser
+        # `EventSource` semantics: a server that emits >=1 event then drops on
+        # every connection can reconnect indefinitely.
+        reconnect_attempts = 0
+
+        # ``None`` means there is no live stream to read this iteration (e.g. a
+        # failed reconnect); the loop then re-evaluates the reconnect decision
+        # without re-reading an exhausted response.
+        response: Optional[httpx.Response] = self._response
+        # Context manager for a response we opened ourselves and must close.
+        # The initial response is owned by the caller, so it starts as None.
+        owned_cm: Optional[ContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    for sse in self._decode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
+
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
+
+                self._sleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
+
+                # Close the previously-opened reconnect response before opening
+                # a new one so we never hold more than one extra connection.
+                if owned_cm is not None:
+                    owned_cm.__exit__(None, None, None)
+                    owned_cm = None
+
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: ContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = cm.__enter__()
+                except Exception:
+                    # A failed reconnect consumes an attempt; back off and retry.
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    # Null/empty reconnect body: treat as a failed attempt.
+                    response = None
+                    continue
+
+                response = new_response
+                # Drop any partial event left over from the dropped stream, but
+                # keep the last event id (per the SSE spec) and start a fresh
+                # incremental text decoder for the new connection.
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                owned_cm.__exit__(None, None, None)
 
     async def aiter_sse(self) -> AsyncGenerator[ServerSentEvent, None]:
         self._check_content_type()
         decoder = SSEDecoder()
-        charset = self._get_charset()
-        text_decoder = codecs.getincrementaldecoder(charset)(errors="replace")
+        text_decoder = self._new_text_decoder()
 
-        buf = ""
-        async for chunk in self._response.aiter_bytes():
-            buf += text_decoder.decode(chunk)
-            buf = self._normalize_sse_line_endings(buf)
+        last_dispatched_id: Optional[str] = None
+        last_retry: Optional[int] = None
+        reconnect_attempts = 0
 
-            while "\n" in buf:
-                line, buf = buf.split("\n", 1)
-                sse = decoder.decode(line)
-                if sse is not None:
-                    yield sse
+        response: Optional[httpx.Response] = self._response
+        owned_cm: Optional[AsyncContextManager[httpx.Response]] = None
+        try:
+            while True:
+                if response is not None:
+                    async for sse in self._adecode_response(response, decoder, text_decoder):
+                        yield sse
+                        if sse.id:
+                            last_dispatched_id = sse.id
+                        if sse.retry is not None:
+                            last_retry = sse.retry
+                        reconnect_attempts = 0
 
-            if len(buf) > MAX_LINE_SIZE:
-                raise SSEError(
-                    f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-                )
+                if not self._should_reconnect(last_dispatched_id, reconnect_attempts):
+                    return
+                reconnect_attempts += 1
 
-        # Flush any remaining bytes from the incremental decoder
-        buf += text_decoder.decode(b"", final=True)
-        buf = buf.replace("\r\n", "\n").replace("\r", "\n")
+                await self._asleep_before_reconnect(last_retry)
+                if self._is_cancelled():
+                    return
 
-        if len(buf) > MAX_LINE_SIZE:
-            raise SSEError(
-                f"SSE line exceeded maximum size of {MAX_LINE_SIZE} characters without encountering a newline"
-            )
+                if owned_cm is not None:
+                    await owned_cm.__aexit__(None, None, None)
+                    owned_cm = None
 
-        while "\n" in buf:
-            line, buf = buf.split("\n", 1)
-            sse = decoder.decode(line)
-            if sse is not None:
-                yield sse
+                assert self._reconnect is not None  # guaranteed by _should_reconnect
+                try:
+                    cm: AsyncContextManager[httpx.Response] = self._reconnect(last_dispatched_id or "")
+                    new_response = await cm.__aenter__()
+                except Exception:
+                    response = None
+                    continue
+                owned_cm = cm
+                if new_response is None:
+                    response = None
+                    continue
 
-        if buf.strip():
-            sse = decoder.decode(buf)
-            if sse is not None:
-                yield sse
+                response = new_response
+                decoder.reset_in_progress_event()
+                text_decoder = self._new_text_decoder()
+        finally:
+            if owned_cm is not None:
+                await owned_cm.__aexit__(None, None, None)
 
 
 @contextmanager

--- a/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_decoders.py
+++ b/seed/python-sdk/x-fern-global-parameters/src/seed/core/http_sse/_decoders.py
@@ -12,6 +12,19 @@ class SSEDecoder:
         self._last_event_id = ""
         self._retry: Optional[int] = None
 
+    def reset_in_progress_event(self) -> None:
+        """Discard any partially-parsed (undispatched) event.
+
+        Used when a stream ends mid-event before reconnecting: the buffered
+        ``event``/``data``/``retry`` fields of the never-dispatched event must
+        be dropped so they do not corrupt the first event of the reconnected
+        stream. Per the SSE spec the last event id is *not* reset here — it
+        persists across connections.
+        """
+        self._event = ""
+        self._data = []
+        self._retry = None
+
     def decode(self, line: str) -> Optional[ServerSentEvent]:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 


### PR DESCRIPTION
## Description
Brings the Python SDK generator's SSE auto-reconnection to parity with the merged TypeScript implementation (#16864) and the existing Go behavior. The reconnection *parameters* (`resumable`, `stream_reconnection_enabled`, `max_stream_reconnection_attempts`) were already plumbed onto `EventSource`, but the actual reconnect loop was never wired up — `iter_sse`/`aiter_sse` iterated a single HTTP response and ignored those flags. This PR implements the loop and generates the `_reconnect` callback for resumable SSE endpoints.

## Changes Made
- **Runtime (`core_utilities/shared/http_sse/_api.py`)**: implemented the reconnection loop in both sync `iter_sse` and async `aiter_sse`. When a `resumable: true` stream ends prematurely, `EventSource` re-issues the original request (via a generated `_reconnect(last_event_id)` callback returning a fresh streaming context manager) with a `Last-Event-ID` header and resumes.
  - Gated by `_should_reconnect`: only resumable endpoints; requires a configured `stream_terminator` (otherwise a clean end is indistinguishable from a drop → no reconnect); respects `stream_reconnection_enabled`; requires a last *dispatched* id; caps at `max_stream_reconnection_attempts` (default 5).
  - **Reset-on-progress**: the consecutive-attempt counter resets to 0 whenever an event is successfully dispatched (matches browser `EventSource` — a server that emits ≥1 event then drops each time can reconnect indefinitely).
  - **Backoff & cancellation**: default 1s (`DEFAULT_RECONNECT_DELAY_MS`) when the server sends no `retry:`; otherwise the server `retry:` value, clamped to 30s (`MAX_RECONNECT_DELAY_MS`). The delay is cancellable: async awaits cancellation-aware `anyio.sleep` (a cancelled task / closed generator aborts before re-issuing); sync uses `time.sleep`, which stays interruptible by signals (e.g. `KeyboardInterrupt`).
  - **Premature end includes transport errors**: a real drop typically surfaces mid-read as an `httpx.TransportError` (e.g. `RemoteProtocolError`/`ReadError`), not just a clean EOF. Both are now treated as a premature end that triggers reconnection, while a genuine protocol violation (`SSEError`, e.g. oversized line) propagates.
  - **Null/empty reconnect body** (e.g. 204/304 → no usable body) is treated as a failed attempt (consume an attempt, back off, retry) rather than crashing or re-reading the exhausted response.
  - **Last-*dispatched*-id resume (critical correctness)**: reconnection resumes from the id of the last *dispatched* `ServerSentEvent`, never a parsed-but-undispatched `id:`. Prevents silent event loss when a drop occurs after an `id:` line but before its terminating blank line.
- **`_decoders.py`**: added `reset_in_progress_event()` to drop a partially-parsed (never-dispatched) event on reconnect while preserving the last event id per the SSE spec.
- **Generator wiring** (gated to resumable SSE endpoints only — no change for non-resumable/non-SSE):
  - `external_dependencies/httpx.py`: emits a `_reconnect` closure that re-issues the original request with the `Last-Event-ID` header merged into existing headers, and passes `reconnect=`/`stream_terminator=` into the `EventSource(...)` constructor.
  - `client_generator/endpoint_response_code_writer.py`, `endpoint_function_generator.py` (`is_resumable_sse_endpoint` helper), `client_generator/constants.py` (`SSE_RECONNECT_VARIABLE`).
- **Fixtures**: regenerated all `python-sdk` seed fixtures. Generated-code changes: `server-sent-events-resumable/.../completions/raw_client.py` (emits the `_reconnect` closure + `reconnect=`/`stream_terminator=` kwargs); all fixtures pick up the shared `http_sse/_api.py` + `_decoders.py` runtime updates.
- **Changelog**: `generators/python/sdk/changes/unreleased/sse-auto-reconnection.yml` (`feat`).

## Follow-up in this branch: e2e-driven correctness fix
An end-to-end test against a **real local HTTP server that drops SSE connections** surfaced a bug the in-memory unit fakes could not: the original cancellation check used `self._response.is_closed`, but a fully-consumed real `httpx` stream reports `is_closed=True` on normal completion — so after the first drop the client mistook completion for cancellation and **never reconnected**. Fixed by removing the `is_closed` heuristic (async → `anyio.sleep`, sync → interruptible `time.sleep`) and treating mid-stream transport errors as premature ends. Added permanent real-socket integration tests (`TestSSEReconnectionEndToEnd`, sync + async).

## Parity vs TypeScript

| Behavior | TS | Python (this PR) |
|---|---|---|
| Reconnect on premature end via `Last-Event-ID` | ✅ | ✅ |
| Terminator gating (no terminator → no reconnect) | ✅ | ✅ |
| `reconnectionEnabled` / `stream_reconnection_enabled=false` → never | ✅ | ✅ |
| Max consecutive attempts cap + reset-on-progress | ✅ | ✅ |
| Backoff 1s default; server `retry:` clamped to 30s | ✅ | ✅ |
| Cancellable during backoff delay | ✅ | ✅ (`anyio.sleep` async / signal-interruptible `time.sleep` sync) |
| Null/empty reconnect body → failed attempt | ✅ | ✅ |
| Resume from last **dispatched** id (not parsed) | ✅ | ✅ |

## Testing
- [x] Unit tests added/updated — `generators/python/tests/utils/test_http_sse.py` covers all parity scenarios for **both sync and async**: basic reconnect w/ correct `Last-Event-ID`, multiple sequential reconnects, no-terminator, `stream_reconnection_enabled=False`, not-resumable, max-attempts cap, reset-on-progress, clean-terminator (no reconnect), null-body-as-failed-attempt, default/zero/server/clamped backoff, backoff interruptibility, and the **mid-event-drop regression** (`test_reconnects_from_last_dispatched_id_not_parsed_id`).
- [x] **End-to-end tests over a real socket** — `TestSSEReconnectionEndToEnd` runs a real `ThreadingHTTPServer` that drops the connection mid-stream and a real `httpx.Client`/`AsyncClient`. Asserts all events arrive in order across reconnects and that the server saw `Last-Event-ID: [None, "2", "4"]` — including a first connection that sends `id: 3` (parsed, never dispatched) then drops, proving the client resumes from the last *dispatched* id (`2`) with no event loss.
- [x] Verification (local):
  - `generators/python`: `poetry run mypy .` → clean (335 files); `poetry run pytest` → **269 passed** (92 in the SSE suite, incl. 2 real-socket e2e); `poetry run pre-commit run -a` → all passed.
  - Regenerated fixture `seed/python-sdk/server-sent-events-resumable`: `poetry run mypy .` → clean (45 files); `poetry run pytest` → 66 passed, 4 skipped.
  - CI: all 50 checks green (incl. full `python-sdk` seed matrix, changelog/versions validation).

Link to Devin session: https://app.devin.ai/sessions/7ea357979cc144be9e6c8d1106f39c99
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->