### PR TITLE
fix(python): emit attribute docstrings for aliased pydantic model fields

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-aliased-field-docstrings.yml
+++ b/generators/python/sdk/changes/unreleased/fix-aliased-field-docstrings.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Emit attribute docstrings for aliased Pydantic model fields (e.g. fields renamed
+    from camelCase wire names to snake_case) so IDEs surface the field description
+    on hover, matching the behavior of non-aliased fields.
+  type: fix

--- a/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
+++ b/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
@@ -133,6 +133,7 @@ class PydanticModel:
         # default value as a plain initializer outside the Annotated pattern.
         use_annotated_pattern = is_aliased
 
+        field_docstring: Optional[AST.Docstring] = None
         if use_annotated_pattern:
             is_pure_v2 = self._version == PydanticVersionCompatibility.V2
 
@@ -183,6 +184,11 @@ class PydanticModel:
                     initializer = default_value
             else:
                 initializer = None
+
+            # The description inside Annotated[..., pydantic.Field(description=...)] is not
+            # surfaced by IDEs on hover, so also emit an attribute docstring below the field.
+            if field.description is not None:
+                field_docstring = AST.Docstring(field.description)
         else:
             # No alias - use the original behavior
             initializer = get_field_name_initializer(
@@ -194,7 +200,9 @@ class PydanticModel:
             )
 
         self._class_declaration.add_class_var(
-            AST.VariableDeclaration(name=field.name, type_hint=field.type_hint, initializer=initializer)
+            AST.VariableDeclaration(
+                name=field.name, type_hint=field.type_hint, initializer=initializer, docstring=field_docstring
+            )
         )
 
         self._fields.append(field)

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/audit_info.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/audit_info.py
@@ -19,21 +19,36 @@ class AuditInfo(UniversalBaseModel):
         FieldMetadata(alias="createdBy"),
         pydantic.Field(alias="createdBy", description="The user who created this resource."),
     ] = None
+    """
+    The user who created this resource.
+    """
+
     created_date_time: typing_extensions.Annotated[
         typing.Optional[dt.datetime],
         FieldMetadata(alias="createdDateTime"),
         pydantic.Field(alias="createdDateTime", description="When this resource was created."),
     ] = None
+    """
+    When this resource was created.
+    """
+
     modified_by: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="modifiedBy"),
         pydantic.Field(alias="modifiedBy", description="The user who last modified this resource."),
     ] = None
+    """
+    The user who last modified this resource.
+    """
+
     modified_date_time: typing_extensions.Annotated[
         typing.Optional[dt.datetime],
         FieldMetadata(alias="modifiedDateTime"),
         pydantic.Field(alias="modifiedDateTime", description="When this resource was last modified."),
     ] = None
+    """
+    When this resource was last modified.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/plant_base.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/plant_base.py
@@ -30,6 +30,10 @@ class PlantBase(UniversalBaseModel):
         FieldMetadata(alias="commonName"),
         pydantic.Field(alias="commonName", description="The common name of the plant."),
     ] = None
+    """
+    The common name of the plant.
+    """
+
     watering_frequency: typing_extensions.Annotated[
         typing.Optional[PlantBaseWateringFrequency],
         FieldMetadata(alias="wateringFrequency"),

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/rule_response.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/rule_response.py
@@ -17,21 +17,37 @@ class RuleResponse(UniversalBaseModel):
         FieldMetadata(alias="createdBy"),
         pydantic.Field(alias="createdBy", description="The user who created this resource."),
     ] = None
+    """
+    The user who created this resource.
+    """
+
     created_date_time: typing_extensions.Annotated[
         typing.Optional[dt.datetime],
         FieldMetadata(alias="createdDateTime"),
         pydantic.Field(alias="createdDateTime", description="When this resource was created."),
     ] = None
+    """
+    When this resource was created.
+    """
+
     modified_by: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="modifiedBy"),
         pydantic.Field(alias="modifiedBy", description="The user who last modified this resource."),
     ] = None
+    """
+    The user who last modified this resource.
+    """
+
     modified_date_time: typing_extensions.Annotated[
         typing.Optional[dt.datetime],
         FieldMetadata(alias="modifiedDateTime"),
         pydantic.Field(alias="modifiedDateTime", description="When this resource was last modified."),
     ] = None
+    """
+    When this resource was last modified.
+    """
+
     id: str
     name: str
     status: RuleResponseStatus

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/tree_base.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/tree_base.py
@@ -19,21 +19,36 @@ class TreeBase(UniversalBaseModel):
         FieldMetadata(alias="treeName"),
         pydantic.Field(alias="treeName", description="Display name of the tree."),
     ] = None
+    """
+    Display name of the tree.
+    """
+
     tree_description: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="treeDescription"),
         pydantic.Field(alias="treeDescription", description="A description of the tree."),
     ] = None
+    """
+    A description of the tree.
+    """
+
     tree_species: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="treeSpecies"),
         pydantic.Field(alias="treeSpecies", description="The species of tree."),
     ] = None
+    """
+    The species of tree.
+    """
+
     height_in_feet: typing_extensions.Annotated[
         typing.Optional[float],
         FieldMetadata(alias="heightInFeet"),
         pydantic.Field(alias="heightInFeet", description="Height of the tree in feet."),
     ] = None
+    """
+    Height of the tree in feet.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/tree_describable.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/tree_describable.py
@@ -14,11 +14,18 @@ class TreeDescribable(UniversalBaseModel):
         FieldMetadata(alias="treeName"),
         pydantic.Field(alias="treeName", description="Display name of the tree."),
     ] = None
+    """
+    Display name of the tree.
+    """
+
     tree_description: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="treeDescription"),
         pydantic.Field(alias="treeDescription", description="A description of the tree."),
     ] = None
+    """
+    A description of the tree.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/tree_record.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/types/tree_record.py
@@ -18,24 +18,43 @@ class TreeRecord(UniversalBaseModel):
     tree_name: typing_extensions.Annotated[
         str, FieldMetadata(alias="treeName"), pydantic.Field(alias="treeName", description="Display name of the tree.")
     ]
+    """
+    Display name of the tree.
+    """
+
     tree_description: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="treeDescription"),
         pydantic.Field(alias="treeDescription", description="A description of the tree."),
     ] = None
+    """
+    A description of the tree.
+    """
+
     tree_species: typing_extensions.Annotated[
         str, FieldMetadata(alias="treeSpecies"), pydantic.Field(alias="treeSpecies", description="The species of tree.")
     ]
+    """
+    The species of tree.
+    """
+
     height_in_feet: typing_extensions.Annotated[
         typing.Optional[float],
         FieldMetadata(alias="heightInFeet"),
         pydantic.Field(alias="heightInFeet", description="Height of the tree in feet."),
     ] = None
+    """
+    Height of the tree in feet.
+    """
+
     planted_date: typing_extensions.Annotated[
         typing.Optional[dt.date],
         FieldMetadata(alias="plantedDate"),
         pydantic.Field(alias="plantedDate", description="Date the tree was planted."),
     ] = None
+    """
+    Date the tree was planted.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof/no-custom-config/src/seed/types/audit_info.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/types/audit_info.py
@@ -19,21 +19,36 @@ class AuditInfo(UniversalBaseModel):
         FieldMetadata(alias="createdBy"),
         pydantic.Field(alias="createdBy", description="The user who created this resource."),
     ] = None
+    """
+    The user who created this resource.
+    """
+
     created_date_time: typing_extensions.Annotated[
         typing.Optional[dt.datetime],
         FieldMetadata(alias="createdDateTime"),
         pydantic.Field(alias="createdDateTime", description="When this resource was created."),
     ] = None
+    """
+    When this resource was created.
+    """
+
     modified_by: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="modifiedBy"),
         pydantic.Field(alias="modifiedBy", description="The user who last modified this resource."),
     ] = None
+    """
+    The user who last modified this resource.
+    """
+
     modified_date_time: typing_extensions.Annotated[
         typing.Optional[dt.datetime],
         FieldMetadata(alias="modifiedDateTime"),
         pydantic.Field(alias="modifiedDateTime", description="When this resource was last modified."),
     ] = None
+    """
+    When this resource was last modified.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof/no-custom-config/src/seed/types/plant_base.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/types/plant_base.py
@@ -16,6 +16,10 @@ class PlantBase(PlantStrict):
         FieldMetadata(alias="commonName"),
         pydantic.Field(alias="commonName", description="The common name of the plant."),
     ] = None
+    """
+    The common name of the plant.
+    """
+
     watering_frequency: typing_extensions.Annotated[
         typing.Optional[PlantBaseWateringFrequency],
         FieldMetadata(alias="wateringFrequency"),

--- a/seed/python-sdk/allof/no-custom-config/src/seed/types/tree_base.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/types/tree_base.py
@@ -16,11 +16,18 @@ class TreeBase(TreeIdentifiable, TreeDescribable):
         FieldMetadata(alias="treeSpecies"),
         pydantic.Field(alias="treeSpecies", description="The species of tree."),
     ] = None
+    """
+    The species of tree.
+    """
+
     height_in_feet: typing_extensions.Annotated[
         typing.Optional[float],
         FieldMetadata(alias="heightInFeet"),
         pydantic.Field(alias="heightInFeet", description="Height of the tree in feet."),
     ] = None
+    """
+    Height of the tree in feet.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof/no-custom-config/src/seed/types/tree_describable.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/types/tree_describable.py
@@ -14,11 +14,18 @@ class TreeDescribable(UniversalBaseModel):
         FieldMetadata(alias="treeName"),
         pydantic.Field(alias="treeName", description="Display name of the tree."),
     ] = None
+    """
+    Display name of the tree.
+    """
+
     tree_description: typing_extensions.Annotated[
         typing.Optional[str],
         FieldMetadata(alias="treeDescription"),
         pydantic.Field(alias="treeDescription", description="A description of the tree."),
     ] = None
+    """
+    A description of the tree.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/allof/no-custom-config/src/seed/types/tree_record.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/types/tree_record.py
@@ -16,6 +16,9 @@ class TreeRecord(TreeBase):
         FieldMetadata(alias="plantedDate"),
         pydantic.Field(alias="plantedDate", description="Date the tree was planted."),
     ] = None
+    """
+    Date the tree was planted.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/client-side-params/src/seed/types/types/client.py
+++ b/seed/python-sdk/client-side-params/src/seed/types/types/client.py
@@ -38,6 +38,10 @@ class Client(UniversalBaseModel):
         FieldMetadata(alias="global"),
         pydantic.Field(alias="global", description="Whether this is a global client"),
     ] = None
+    """
+    Whether this is a global client
+    """
+
     client_secret: typing.Optional[str] = pydantic.Field(default=None)
     """
     The client secret (only for non-public clients)

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -24,11 +24,18 @@ class ObjectWithDatetimeLikeString(UncheckedBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/types/object/types/object_with_datetime_like_string.py
@@ -14,7 +14,15 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
     should preserve its exact value even if it looks like a datetime.
     """
     datetime_like_string: typing_extensions.Annotated[str, FieldMetadata(alias="datetimeLikeString"), pydantic.Field(alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value")]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+    
     actual_datetime: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="actualDatetime"), pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison")]
+    """
+    An actual datetime field for comparison
+    """
+    
     
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/types/object/types/object_with_datetime_like_string.py
@@ -14,7 +14,15 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
     should preserve its exact value even if it looks like a datetime.
     """
     datetime_like_string: typing_extensions.Annotated[str, FieldMetadata(alias="datetimeLikeString"), pydantic.Field(alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value")]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+    
     actual_datetime: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="actualDatetime"), pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison")]
+    """
+    An actual datetime field for comparison
+    """
+    
     
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/types/object/types/object_with_datetime_like_string.py
@@ -14,7 +14,15 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
     should preserve its exact value even if it looks like a datetime.
     """
     datetime_like_string: typing_extensions.Annotated[str, FieldMetadata(alias="datetimeLikeString"), pydantic.Field(alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value")]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+    
     actual_datetime: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="actualDatetime"), pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison")]
+    """
+    An actual datetime field for comparison
+    """
+    
     
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -22,11 +22,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -22,11 +22,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -22,11 +22,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,10 +23,17 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -24,11 +24,18 @@ class ObjectWithDatetimeLikeString(UncheckedBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/object_with_datetime_like_string.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/object_with_datetime_like_string.py
@@ -23,11 +23,18 @@ class ObjectWithDatetimeLikeString(UniversalBaseModel):
             alias="datetimeLikeString", description="A string field that happens to contain a datetime-like value"
         ),
     ]
+    """
+    A string field that happens to contain a datetime-like value
+    """
+
     actual_datetime: typing_extensions.Annotated[
         dt.datetime,
         FieldMetadata(alias="actualDatetime"),
         pydantic.Field(alias="actualDatetime", description="An actual datetime field for comparison"),
     ]
+    """
+    An actual datetime field for comparison
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/property-access/src/seed/types/admin.py
+++ b/seed/python-sdk/property-access/src/seed/types/admin.py
@@ -19,6 +19,9 @@ class Admin(User):
         FieldMetadata(alias="adminLevel"),
         pydantic.Field(alias="adminLevel", description="The level of admin privileges."),
     ]
+    """
+    The level of admin privileges.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/types/completion_full_response.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/types/completion_full_response.py
@@ -24,6 +24,9 @@ class CompletionFullResponse(UniversalBaseModel):
         FieldMetadata(alias="finishReason"),
         pydantic.Field(alias="finishReason", description="Why generation stopped."),
     ] = None
+    """
+    Why generation stopped.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/list_type.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/list_type.py
@@ -22,6 +22,9 @@ class ListType(UniversalBaseModel):
             description="Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.",
         ),
     ] = None
+    """
+    Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/execution_session_state.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/execution_session_state.py
@@ -19,6 +19,10 @@ class ExecutionSessionState(UniversalBaseModel):
         FieldMetadata(alias="sessionId"),
         pydantic.Field(alias="sessionId", description="The auto-generated session id. Formatted as a uuid."),
     ]
+    """
+    The auto-generated session id. Formatted as a uuid.
+    """
+
     is_warm_instance: typing_extensions.Annotated[
         bool, FieldMetadata(alias="isWarmInstance"), pydantic.Field(alias="isWarmInstance")
     ]


### PR DESCRIPTION
## Description
Fields whose wire name differs from the Python name (e.g. `collegeId` → `college_id`) are generated with the `Annotated[..., pydantic.Field(alias=..., description=...)]` pattern. Unlike non-aliased fields — which get a PEP 257 attribute docstring right below the assignment — aliased fields carried their description only inside `pydantic.Field(description=...)`, which IDEs (Pylance/Pyright) do not surface on hover. As a result, hovering `response.college_id` showed no documentation while `response.id` did.

This PR emits the attribute docstring for aliased fields as well:

```python
admin_level: typing_extensions.Annotated[
    str,
    FieldMetadata(alias="adminLevel"),
    pydantic.Field(alias="adminLevel", description="The level of admin privileges."),
]
"""
The level of admin privileges.
"""
```

## Changes Made
- `generators/python/src/fern_python/pydantic_codegen/pydantic_model.py`: in the aliased (`Annotated`) branch of `PydanticModel.add_field`, attach an `AST.Docstring` to the field's `VariableDeclaration` when the field has a description (non-aliased fields already emit docstrings via `get_field_name_initializer`)
- Added unreleased changelog entry for the Python SDK generator
- Regenerated `seed/python-sdk` output (docstring-only additions across affected fixtures)

## Testing
- [x] Python generator unit tests pass (`poetry run pytest tests`, 276 passed) and `mypy` clean
- [x] `seed test --generator python-sdk --skip-scripts`: 196/196 test cases passed; verified diff is docstring additions only

Link to Devin session: https://app.devin.ai/sessions/bc3a5db880b343ab90452234dfe79fdc
Requested by: @iamnamananand996