### PR TITLE
fix(go): decompress gzip responses that net/http skips when the spec sets an explicit Accept-Encoding header

### DIFF
--- a/generators/go-v2/base/src/asIs/internal/caller.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller.go_
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/generators/go-v2/base/src/asIs/internal/caller.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller.go_
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/generators/go-v2/base/src/asIs/internal/caller.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller.go_
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/generators/go-v2/base/src/asIs/internal/caller.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller.go_
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/generators/go-v2/base/src/asIs/internal/caller.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller.go_
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/generators/go-v2/base/src/asIs/internal/caller.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller.go_
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/generators/go-v2/base/src/asIs/internal/caller_test.go_
+++ b/generators/go-v2/base/src/asIs/internal/caller_test.go_
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/generators/go-v2/base/src/asIs/internal/retrier.go_
+++ b/generators/go-v2/base/src/asIs/internal/retrier.go_
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt + 1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/generators/go-v2/base/src/asIs/internal/streamer.go_
+++ b/generators/go-v2/base/src/asIs/internal/streamer.go_
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/generators/go-v2/base/src/asIs/internal/streamer.go_
+++ b/generators/go-v2/base/src/asIs/internal/streamer.go_
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/generators/go-v2/base/src/asIs/internal/streamer.go_
+++ b/generators/go-v2/base/src/asIs/internal/streamer.go_
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/generators/go/sdk/changes/unreleased/fix-gzip-response-decompression.yml
+++ b/generators/go/sdk/changes/unreleased/fix-gzip-response-decompression.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Decompress gzip-encoded response bodies when the `Accept-Encoding` header is set
+    explicitly on the request. Go's `net/http` only performs transparent gzip
+    decompression when it adds the `Accept-Encoding` header itself, so responses to
+    requests with a spec-defined `Accept-Encoding: gzip` header were previously
+    returned as raw gzip bytes.
+  type: fix

--- a/seed/go-sdk/accept-header/.fern/metadata.json
+++ b/seed/go-sdk/accept-header/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/accept-header/internal/caller.go
+++ b/seed/go-sdk/accept-header/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/accept-header/internal/caller.go
+++ b/seed/go-sdk/accept-header/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/accept-header/internal/caller.go
+++ b/seed/go-sdk/accept-header/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/accept-header/internal/caller.go
+++ b/seed/go-sdk/accept-header/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/accept-header/internal/caller.go
+++ b/seed/go-sdk/accept-header/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/accept-header/internal/caller.go
+++ b/seed/go-sdk/accept-header/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/accept-header/internal/caller_test.go
+++ b/seed/go-sdk/accept-header/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/accept-header/internal/retrier.go
+++ b/seed/go-sdk/accept-header/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/alias-extends/.fern/metadata.json
+++ b/seed/go-sdk/alias-extends/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/alias-extends/internal/caller.go
+++ b/seed/go-sdk/alias-extends/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/alias-extends/internal/caller.go
+++ b/seed/go-sdk/alias-extends/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/alias-extends/internal/caller.go
+++ b/seed/go-sdk/alias-extends/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/alias-extends/internal/caller.go
+++ b/seed/go-sdk/alias-extends/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/alias-extends/internal/caller.go
+++ b/seed/go-sdk/alias-extends/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/alias-extends/internal/caller.go
+++ b/seed/go-sdk/alias-extends/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/alias-extends/internal/caller_test.go
+++ b/seed/go-sdk/alias-extends/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/alias-extends/internal/retrier.go
+++ b/seed/go-sdk/alias-extends/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/alias/.fern/metadata.json
+++ b/seed/go-sdk/alias/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/alias/internal/caller.go
+++ b/seed/go-sdk/alias/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/alias/internal/caller.go
+++ b/seed/go-sdk/alias/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/alias/internal/caller.go
+++ b/seed/go-sdk/alias/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/alias/internal/caller.go
+++ b/seed/go-sdk/alias/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/alias/internal/caller.go
+++ b/seed/go-sdk/alias/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/alias/internal/caller.go
+++ b/seed/go-sdk/alias/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/alias/internal/caller_test.go
+++ b/seed/go-sdk/alias/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/alias/internal/retrier.go
+++ b/seed/go-sdk/alias/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/allof-inline/.fern/metadata.json
+++ b/seed/go-sdk/allof-inline/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/allof-inline/internal/caller.go
+++ b/seed/go-sdk/allof-inline/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/allof-inline/internal/caller.go
+++ b/seed/go-sdk/allof-inline/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/allof-inline/internal/caller.go
+++ b/seed/go-sdk/allof-inline/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/allof-inline/internal/caller.go
+++ b/seed/go-sdk/allof-inline/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/allof-inline/internal/caller.go
+++ b/seed/go-sdk/allof-inline/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/allof-inline/internal/caller.go
+++ b/seed/go-sdk/allof-inline/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/allof-inline/internal/caller_test.go
+++ b/seed/go-sdk/allof-inline/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/allof-inline/internal/retrier.go
+++ b/seed/go-sdk/allof-inline/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/allof/.fern/metadata.json
+++ b/seed/go-sdk/allof/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/allof/internal/caller.go
+++ b/seed/go-sdk/allof/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/allof/internal/caller.go
+++ b/seed/go-sdk/allof/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/allof/internal/caller.go
+++ b/seed/go-sdk/allof/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/allof/internal/caller.go
+++ b/seed/go-sdk/allof/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/allof/internal/caller.go
+++ b/seed/go-sdk/allof/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/allof/internal/caller.go
+++ b/seed/go-sdk/allof/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/allof/internal/caller_test.go
+++ b/seed/go-sdk/allof/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/allof/internal/retrier.go
+++ b/seed/go-sdk/allof/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/any-auth/.fern/metadata.json
+++ b/seed/go-sdk/any-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/any-auth/internal/caller.go
+++ b/seed/go-sdk/any-auth/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/any-auth/internal/caller.go
+++ b/seed/go-sdk/any-auth/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/any-auth/internal/caller.go
+++ b/seed/go-sdk/any-auth/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/any-auth/internal/caller.go
+++ b/seed/go-sdk/any-auth/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/any-auth/internal/caller.go
+++ b/seed/go-sdk/any-auth/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/any-auth/internal/caller.go
+++ b/seed/go-sdk/any-auth/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/any-auth/internal/caller_test.go
+++ b/seed/go-sdk/any-auth/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/any-auth/internal/retrier.go
+++ b/seed/go-sdk/any-auth/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/go-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/caller_test.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/retrier.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/go-sdk/api-wide-base-path/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/api-wide-base-path/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/api-wide-base-path/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/api-wide-base-path/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/api-wide-base-path/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/api-wide-base-path/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/api-wide-base-path/internal/caller.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/api-wide-base-path/internal/caller_test.go
+++ b/seed/go-sdk/api-wide-base-path/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/api-wide-base-path/internal/retrier.go
+++ b/seed/go-sdk/api-wide-base-path/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/audiences/.fern/metadata.json
+++ b/seed/go-sdk/audiences/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/audiences/internal/caller.go
+++ b/seed/go-sdk/audiences/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/audiences/internal/caller.go
+++ b/seed/go-sdk/audiences/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/audiences/internal/caller.go
+++ b/seed/go-sdk/audiences/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/audiences/internal/caller.go
+++ b/seed/go-sdk/audiences/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/audiences/internal/caller.go
+++ b/seed/go-sdk/audiences/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/audiences/internal/caller.go
+++ b/seed/go-sdk/audiences/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/audiences/internal/caller_test.go
+++ b/seed/go-sdk/audiences/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/audiences/internal/retrier.go
+++ b/seed/go-sdk/audiences/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/go-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/basic-auth-environment-variables/internal/caller_test.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/basic-auth-environment-variables/internal/retrier.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller_test.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/retrier.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/basic-auth/.fern/metadata.json
+++ b/seed/go-sdk/basic-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/basic-auth/internal/caller.go
+++ b/seed/go-sdk/basic-auth/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/basic-auth/internal/caller.go
+++ b/seed/go-sdk/basic-auth/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/basic-auth/internal/caller.go
+++ b/seed/go-sdk/basic-auth/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/basic-auth/internal/caller.go
+++ b/seed/go-sdk/basic-auth/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/basic-auth/internal/caller.go
+++ b/seed/go-sdk/basic-auth/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/basic-auth/internal/caller.go
+++ b/seed/go-sdk/basic-auth/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/basic-auth/internal/caller_test.go
+++ b/seed/go-sdk/basic-auth/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/basic-auth/internal/retrier.go
+++ b/seed/go-sdk/basic-auth/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/go-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/bearer-token-environment-variable/internal/caller_test.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/bearer-token-environment-variable/internal/retrier.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/bytes-download/.fern/metadata.json
+++ b/seed/go-sdk/bytes-download/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/bytes-download/internal/caller.go
+++ b/seed/go-sdk/bytes-download/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/bytes-download/internal/caller.go
+++ b/seed/go-sdk/bytes-download/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/bytes-download/internal/caller.go
+++ b/seed/go-sdk/bytes-download/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/bytes-download/internal/caller.go
+++ b/seed/go-sdk/bytes-download/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/bytes-download/internal/caller.go
+++ b/seed/go-sdk/bytes-download/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/bytes-download/internal/caller.go
+++ b/seed/go-sdk/bytes-download/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/bytes-download/internal/caller_test.go
+++ b/seed/go-sdk/bytes-download/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/bytes-download/internal/retrier.go
+++ b/seed/go-sdk/bytes-download/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/go-sdk/bytes-upload/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/bytes-upload/internal/caller.go
+++ b/seed/go-sdk/bytes-upload/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/bytes-upload/internal/caller.go
+++ b/seed/go-sdk/bytes-upload/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/bytes-upload/internal/caller.go
+++ b/seed/go-sdk/bytes-upload/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/bytes-upload/internal/caller.go
+++ b/seed/go-sdk/bytes-upload/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/bytes-upload/internal/caller.go
+++ b/seed/go-sdk/bytes-upload/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/bytes-upload/internal/caller.go
+++ b/seed/go-sdk/bytes-upload/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/bytes-upload/internal/caller_test.go
+++ b/seed/go-sdk/bytes-upload/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/bytes-upload/internal/retrier.go
+++ b/seed/go-sdk/bytes-upload/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/go-sdk/circular-references-advanced/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/circular-references-advanced/internal/caller.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/circular-references-advanced/internal/caller.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/circular-references-advanced/internal/caller.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/circular-references-advanced/internal/caller.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/circular-references-advanced/internal/caller.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/circular-references-advanced/internal/caller.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/circular-references-advanced/internal/caller_test.go
+++ b/seed/go-sdk/circular-references-advanced/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/circular-references-advanced/internal/retrier.go
+++ b/seed/go-sdk/circular-references-advanced/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/go-sdk/circular-references-extends/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/circular-references-extends/internal/caller.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/circular-references-extends/internal/caller.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/circular-references-extends/internal/caller.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/circular-references-extends/internal/caller.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/circular-references-extends/internal/caller.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/circular-references-extends/internal/caller.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/circular-references-extends/internal/caller_test.go
+++ b/seed/go-sdk/circular-references-extends/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/circular-references-extends/internal/retrier.go
+++ b/seed/go-sdk/circular-references-extends/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/circular-references/.fern/metadata.json
+++ b/seed/go-sdk/circular-references/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/circular-references/internal/caller.go
+++ b/seed/go-sdk/circular-references/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/circular-references/internal/caller.go
+++ b/seed/go-sdk/circular-references/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/circular-references/internal/caller.go
+++ b/seed/go-sdk/circular-references/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/circular-references/internal/caller.go
+++ b/seed/go-sdk/circular-references/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/circular-references/internal/caller.go
+++ b/seed/go-sdk/circular-references/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/circular-references/internal/caller.go
+++ b/seed/go-sdk/circular-references/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/circular-references/internal/caller_test.go
+++ b/seed/go-sdk/circular-references/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/circular-references/internal/retrier.go
+++ b/seed/go-sdk/circular-references/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/cli-multi-spec-namespaced/.fern/metadata.json
+++ b/seed/go-sdk/cli-multi-spec-namespaced/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/caller_test.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/retrier.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/cli-multi-spec/.fern/metadata.json
+++ b/seed/go-sdk/cli-multi-spec/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/cli-multi-spec/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/cli-multi-spec/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/cli-multi-spec/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/cli-multi-spec/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/cli-multi-spec/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/cli-multi-spec/internal/caller.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/cli-multi-spec/internal/caller_test.go
+++ b/seed/go-sdk/cli-multi-spec/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/cli-multi-spec/internal/retrier.go
+++ b/seed/go-sdk/cli-multi-spec/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/client-side-params/.fern/metadata.json
+++ b/seed/go-sdk/client-side-params/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/client-side-params/internal/caller.go
+++ b/seed/go-sdk/client-side-params/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/client-side-params/internal/caller.go
+++ b/seed/go-sdk/client-side-params/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/client-side-params/internal/caller.go
+++ b/seed/go-sdk/client-side-params/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/client-side-params/internal/caller.go
+++ b/seed/go-sdk/client-side-params/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/client-side-params/internal/caller.go
+++ b/seed/go-sdk/client-side-params/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/client-side-params/internal/caller.go
+++ b/seed/go-sdk/client-side-params/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/client-side-params/internal/caller_test.go
+++ b/seed/go-sdk/client-side-params/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/client-side-params/internal/retrier.go
+++ b/seed/go-sdk/client-side-params/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/content-type/.fern/metadata.json
+++ b/seed/go-sdk/content-type/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/content-type/internal/caller.go
+++ b/seed/go-sdk/content-type/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/content-type/internal/caller.go
+++ b/seed/go-sdk/content-type/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/content-type/internal/caller.go
+++ b/seed/go-sdk/content-type/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/content-type/internal/caller.go
+++ b/seed/go-sdk/content-type/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/content-type/internal/caller.go
+++ b/seed/go-sdk/content-type/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/content-type/internal/caller.go
+++ b/seed/go-sdk/content-type/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/content-type/internal/caller_test.go
+++ b/seed/go-sdk/content-type/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/content-type/internal/retrier.go
+++ b/seed/go-sdk/content-type/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/go-sdk/cross-package-type-names/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/cross-package-type-names/internal/caller.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/cross-package-type-names/internal/caller.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/cross-package-type-names/internal/caller.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/cross-package-type-names/internal/caller.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/cross-package-type-names/internal/caller.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/cross-package-type-names/internal/caller.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/cross-package-type-names/internal/caller_test.go
+++ b/seed/go-sdk/cross-package-type-names/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/cross-package-type-names/internal/retrier.go
+++ b/seed/go-sdk/cross-package-type-names/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/go-sdk/dollar-string-examples/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/dollar-string-examples/internal/caller.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/dollar-string-examples/internal/caller.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/dollar-string-examples/internal/caller.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/dollar-string-examples/internal/caller.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/dollar-string-examples/internal/caller.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/dollar-string-examples/internal/caller.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/dollar-string-examples/internal/caller_test.go
+++ b/seed/go-sdk/dollar-string-examples/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/dollar-string-examples/internal/retrier.go
+++ b/seed/go-sdk/dollar-string-examples/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/empty-clients/.fern/metadata.json
+++ b/seed/go-sdk/empty-clients/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/empty-clients/internal/caller.go
+++ b/seed/go-sdk/empty-clients/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/empty-clients/internal/caller.go
+++ b/seed/go-sdk/empty-clients/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/empty-clients/internal/caller.go
+++ b/seed/go-sdk/empty-clients/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/empty-clients/internal/caller.go
+++ b/seed/go-sdk/empty-clients/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/empty-clients/internal/caller.go
+++ b/seed/go-sdk/empty-clients/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/empty-clients/internal/caller.go
+++ b/seed/go-sdk/empty-clients/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/empty-clients/internal/caller_test.go
+++ b/seed/go-sdk/empty-clients/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/empty-clients/internal/retrier.go
+++ b/seed/go-sdk/empty-clients/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/go-sdk/endpoint-security-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/endpoint-security-auth/internal/caller.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/endpoint-security-auth/internal/caller.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/endpoint-security-auth/internal/caller.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/endpoint-security-auth/internal/caller.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/endpoint-security-auth/internal/caller.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/endpoint-security-auth/internal/caller.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/endpoint-security-auth/internal/caller_test.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/endpoint-security-auth/internal/retrier.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/enum/.fern/metadata.json
+++ b/seed/go-sdk/enum/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/enum/internal/caller.go
+++ b/seed/go-sdk/enum/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/enum/internal/caller.go
+++ b/seed/go-sdk/enum/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/enum/internal/caller.go
+++ b/seed/go-sdk/enum/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/enum/internal/caller.go
+++ b/seed/go-sdk/enum/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/enum/internal/caller.go
+++ b/seed/go-sdk/enum/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/enum/internal/caller.go
+++ b/seed/go-sdk/enum/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/enum/internal/caller_test.go
+++ b/seed/go-sdk/enum/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/enum/internal/retrier.go
+++ b/seed/go-sdk/enum/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/error-property/.fern/metadata.json
+++ b/seed/go-sdk/error-property/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/error-property/internal/caller.go
+++ b/seed/go-sdk/error-property/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/error-property/internal/caller.go
+++ b/seed/go-sdk/error-property/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/error-property/internal/caller.go
+++ b/seed/go-sdk/error-property/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/error-property/internal/caller.go
+++ b/seed/go-sdk/error-property/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/error-property/internal/caller.go
+++ b/seed/go-sdk/error-property/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/error-property/internal/caller.go
+++ b/seed/go-sdk/error-property/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/error-property/internal/caller_test.go
+++ b/seed/go-sdk/error-property/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/error-property/internal/retrier.go
+++ b/seed/go-sdk/error-property/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/errors/.fern/metadata.json
+++ b/seed/go-sdk/errors/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/errors/internal/caller.go
+++ b/seed/go-sdk/errors/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/errors/internal/caller.go
+++ b/seed/go-sdk/errors/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/errors/internal/caller.go
+++ b/seed/go-sdk/errors/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/errors/internal/caller.go
+++ b/seed/go-sdk/errors/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/errors/internal/caller.go
+++ b/seed/go-sdk/errors/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/errors/internal/caller.go
+++ b/seed/go-sdk/errors/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/errors/internal/caller_test.go
+++ b/seed/go-sdk/errors/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/errors/internal/retrier.go
+++ b/seed/go-sdk/errors/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/always-send-required-properties/.fern/metadata.json
+++ b/seed/go-sdk/examples/always-send-required-properties/.fern/metadata.json
@@ -7,8 +7,7 @@
     "alwaysSendRequiredProperties": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/always-send-required-properties/internal/caller_test.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/always-send-required-properties/internal/retrier.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/.fern/metadata.json
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/.fern/metadata.json
@@ -8,8 +8,7 @@
     "clientConstructorName": "New"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller_test.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/retrier.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/client-name/.fern/metadata.json
+++ b/seed/go-sdk/examples/client-name/.fern/metadata.json
@@ -7,8 +7,7 @@
     "clientName": "Acme"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/client-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/client-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/client-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/client-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/client-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/client-name/internal/caller.go
+++ b/seed/go-sdk/examples/client-name/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/client-name/internal/caller_test.go
+++ b/seed/go-sdk/examples/client-name/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/client-name/internal/retrier.go
+++ b/seed/go-sdk/examples/client-name/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/export-all-requests-at-root/.fern/metadata.json
+++ b/seed/go-sdk/examples/export-all-requests-at-root/.fern/metadata.json
@@ -7,8 +7,7 @@
     "exportAllRequestsAtRoot": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/caller_test.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/retrier.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/exported-client-name/.fern/metadata.json
+++ b/seed/go-sdk/examples/exported-client-name/.fern/metadata.json
@@ -7,8 +7,7 @@
     "exportedClientName": "AcmeClient"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/exported-client-name/internal/caller.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/exported-client-name/internal/caller.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/exported-client-name/internal/caller.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/exported-client-name/internal/caller.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/exported-client-name/internal/caller.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/exported-client-name/internal/caller.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/exported-client-name/internal/caller_test.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/exported-client-name/internal/retrier.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/getters-pass-by-value/.fern/metadata.json
+++ b/seed/go-sdk/examples/getters-pass-by-value/.fern/metadata.json
@@ -7,8 +7,7 @@
     "gettersPassByValue": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/caller_test.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/retrier.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/examples/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/package-path/.fern/metadata.json
+++ b/seed/go-sdk/examples/package-path/.fern/metadata.json
@@ -7,8 +7,7 @@
     "packagePath": "pleaseinhere"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller_test.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/retrier.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/go-sdk/examples/readme-config/.fern/metadata.json
@@ -18,8 +18,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/readme-config/internal/caller.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/readme-config/internal/caller.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/readme-config/internal/caller.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/readme-config/internal/caller.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/readme-config/internal/caller.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/readme-config/internal/caller.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/readme-config/internal/caller_test.go
+++ b/seed/go-sdk/examples/readme-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/readme-config/internal/retrier.go
+++ b/seed/go-sdk/examples/readme-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/examples/v0/.fern/metadata.json
+++ b/seed/go-sdk/examples/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/v0/internal/caller.go
+++ b/seed/go-sdk/examples/v0/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/examples/v0/internal/caller.go
+++ b/seed/go-sdk/examples/v0/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/examples/v0/internal/caller.go
+++ b/seed/go-sdk/examples/v0/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/v0/internal/caller.go
+++ b/seed/go-sdk/examples/v0/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/examples/v0/internal/caller.go
+++ b/seed/go-sdk/examples/v0/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/examples/v0/internal/caller.go
+++ b/seed/go-sdk/examples/v0/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/examples/v0/internal/caller_test.go
+++ b/seed/go-sdk/examples/v0/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/examples/v0/internal/retrier.go
+++ b/seed/go-sdk/examples/v0/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
@@ -7,8 +7,7 @@
     "omitEmptyRequestWrappers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/retrier.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/extends/.fern/metadata.json
+++ b/seed/go-sdk/extends/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/extends/internal/caller.go
+++ b/seed/go-sdk/extends/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/extends/internal/caller.go
+++ b/seed/go-sdk/extends/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/extends/internal/caller.go
+++ b/seed/go-sdk/extends/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/extends/internal/caller.go
+++ b/seed/go-sdk/extends/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/extends/internal/caller.go
+++ b/seed/go-sdk/extends/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/extends/internal/caller.go
+++ b/seed/go-sdk/extends/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/extends/internal/caller_test.go
+++ b/seed/go-sdk/extends/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/extends/internal/retrier.go
+++ b/seed/go-sdk/extends/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/extra-properties/.fern/metadata.json
+++ b/seed/go-sdk/extra-properties/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/extra-properties/internal/caller.go
+++ b/seed/go-sdk/extra-properties/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/extra-properties/internal/caller.go
+++ b/seed/go-sdk/extra-properties/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/extra-properties/internal/caller.go
+++ b/seed/go-sdk/extra-properties/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/extra-properties/internal/caller.go
+++ b/seed/go-sdk/extra-properties/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/extra-properties/internal/caller.go
+++ b/seed/go-sdk/extra-properties/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/extra-properties/internal/caller.go
+++ b/seed/go-sdk/extra-properties/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/extra-properties/internal/caller_test.go
+++ b/seed/go-sdk/extra-properties/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/extra-properties/internal/retrier.go
+++ b/seed/go-sdk/extra-properties/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/file-download/.fern/metadata.json
+++ b/seed/go-sdk/file-download/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/file-download/internal/caller.go
+++ b/seed/go-sdk/file-download/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/file-download/internal/caller.go
+++ b/seed/go-sdk/file-download/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/file-download/internal/caller.go
+++ b/seed/go-sdk/file-download/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-download/internal/caller.go
+++ b/seed/go-sdk/file-download/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-download/internal/caller.go
+++ b/seed/go-sdk/file-download/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/file-download/internal/caller.go
+++ b/seed/go-sdk/file-download/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/file-download/internal/caller_test.go
+++ b/seed/go-sdk/file-download/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/file-download/internal/retrier.go
+++ b/seed/go-sdk/file-download/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/go-sdk/file-upload-openapi/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/file-upload-openapi/internal/caller.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/file-upload-openapi/internal/caller.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/file-upload-openapi/internal/caller.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload-openapi/internal/caller.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload-openapi/internal/caller.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/file-upload-openapi/internal/caller.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/file-upload-openapi/internal/caller_test.go
+++ b/seed/go-sdk/file-upload-openapi/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/file-upload-openapi/internal/retrier.go
+++ b/seed/go-sdk/file-upload-openapi/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/file-upload/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/file-upload/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/file-upload/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/file-upload/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/file-upload/package-name/.fern/metadata.json
+++ b/seed/go-sdk/file-upload/package-name/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/file-upload/package-name/internal/caller.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/file-upload/package-name/internal/caller.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/file-upload/package-name/internal/caller.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload/package-name/internal/caller.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload/package-name/internal/caller.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/file-upload/package-name/internal/caller.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/file-upload/package-name/internal/caller_test.go
+++ b/seed/go-sdk/file-upload/package-name/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/file-upload/package-name/internal/retrier.go
+++ b/seed/go-sdk/file-upload/package-name/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/file-upload/v0/.fern/metadata.json
+++ b/seed/go-sdk/file-upload/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/file-upload/v0/internal/caller.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/file-upload/v0/internal/caller.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/file-upload/v0/internal/caller.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload/v0/internal/caller.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/file-upload/v0/internal/caller.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/file-upload/v0/internal/caller.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/file-upload/v0/internal/caller_test.go
+++ b/seed/go-sdk/file-upload/v0/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/file-upload/v0/internal/retrier.go
+++ b/seed/go-sdk/file-upload/v0/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/folders/.fern/metadata.json
+++ b/seed/go-sdk/folders/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/folders/internal/caller.go
+++ b/seed/go-sdk/folders/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/folders/internal/caller.go
+++ b/seed/go-sdk/folders/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/folders/internal/caller.go
+++ b/seed/go-sdk/folders/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/folders/internal/caller.go
+++ b/seed/go-sdk/folders/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/folders/internal/caller.go
+++ b/seed/go-sdk/folders/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/folders/internal/caller.go
+++ b/seed/go-sdk/folders/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/folders/internal/caller_test.go
+++ b/seed/go-sdk/folders/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/folders/internal/retrier.go
+++ b/seed/go-sdk/folders/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-bytes-request/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/.fern/metadata.json
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/.fern/metadata.json
@@ -7,8 +7,7 @@
     "useReaderForBytesRequest": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller_test.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/retrier.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-content-type/.fern/metadata.json
+++ b/seed/go-sdk/go-content-type/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-content-type/internal/caller.go
+++ b/seed/go-sdk/go-content-type/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-content-type/internal/caller.go
+++ b/seed/go-sdk/go-content-type/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-content-type/internal/caller.go
+++ b/seed/go-sdk/go-content-type/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-content-type/internal/caller.go
+++ b/seed/go-sdk/go-content-type/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-content-type/internal/caller.go
+++ b/seed/go-sdk/go-content-type/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-content-type/internal/caller.go
+++ b/seed/go-sdk/go-content-type/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-content-type/internal/caller_test.go
+++ b/seed/go-sdk/go-content-type/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-content-type/internal/retrier.go
+++ b/seed/go-sdk/go-content-type/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-deterministic-ordering/.fern/metadata.json
+++ b/seed/go-sdk/go-deterministic-ordering/.fern/metadata.json
@@ -7,8 +7,7 @@
     "exportAllRequestsAtRoot": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-deterministic-ordering/internal/caller_test.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-deterministic-ordering/internal/retrier.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-nested-cross-package/.fern/metadata.json
+++ b/seed/go-sdk/go-nested-cross-package/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-nested-cross-package/internal/caller.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-nested-cross-package/internal/caller.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-nested-cross-package/internal/caller.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-nested-cross-package/internal/caller.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-nested-cross-package/internal/caller.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-nested-cross-package/internal/caller.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-nested-cross-package/internal/caller_test.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-nested-cross-package/internal/retrier.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-nullable-date-ref/.fern/metadata.json
+++ b/seed/go-sdk/go-nullable-date-ref/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-nullable-date-ref/internal/caller_test.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-nullable-date-ref/internal/retrier.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-optional-literal-alias/.fern/metadata.json
+++ b/seed/go-sdk/go-optional-literal-alias/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-optional-literal-alias/internal/caller_test.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-optional-literal-alias/internal/retrier.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-subpackage-collision/.fern/metadata.json
+++ b/seed/go-sdk/go-subpackage-collision/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-subpackage-collision/internal/caller.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-subpackage-collision/internal/caller.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-subpackage-collision/internal/caller.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-subpackage-collision/internal/caller.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-subpackage-collision/internal/caller.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-subpackage-collision/internal/caller.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-subpackage-collision/internal/caller_test.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-subpackage-collision/internal/retrier.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/.fern/metadata.json
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller_test.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/go-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/header-auth-environment-variable/internal/caller_test.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/header-auth-environment-variable/internal/retrier.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/header-auth/.fern/metadata.json
+++ b/seed/go-sdk/header-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/header-auth/internal/caller.go
+++ b/seed/go-sdk/header-auth/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/header-auth/internal/caller.go
+++ b/seed/go-sdk/header-auth/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/header-auth/internal/caller.go
+++ b/seed/go-sdk/header-auth/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/header-auth/internal/caller.go
+++ b/seed/go-sdk/header-auth/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/header-auth/internal/caller.go
+++ b/seed/go-sdk/header-auth/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/header-auth/internal/caller.go
+++ b/seed/go-sdk/header-auth/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/header-auth/internal/caller_test.go
+++ b/seed/go-sdk/header-auth/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/header-auth/internal/retrier.go
+++ b/seed/go-sdk/header-auth/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/http-head/.fern/metadata.json
+++ b/seed/go-sdk/http-head/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/http-head/internal/caller.go
+++ b/seed/go-sdk/http-head/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/http-head/internal/caller.go
+++ b/seed/go-sdk/http-head/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/http-head/internal/caller.go
+++ b/seed/go-sdk/http-head/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/http-head/internal/caller.go
+++ b/seed/go-sdk/http-head/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/http-head/internal/caller.go
+++ b/seed/go-sdk/http-head/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/http-head/internal/caller.go
+++ b/seed/go-sdk/http-head/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/http-head/internal/caller_test.go
+++ b/seed/go-sdk/http-head/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/http-head/internal/retrier.go
+++ b/seed/go-sdk/http-head/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/go-sdk/idempotency-headers/.fern/metadata.json
@@ -11,8 +11,7 @@
     "includeLegacyClientOptions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/idempotency-headers/internal/caller.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/idempotency-headers/internal/caller.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/idempotency-headers/internal/caller.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/idempotency-headers/internal/caller.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/idempotency-headers/internal/caller.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/idempotency-headers/internal/caller.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/idempotency-headers/internal/caller_test.go
+++ b/seed/go-sdk/idempotency-headers/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/idempotency-headers/internal/retrier.go
+++ b/seed/go-sdk/idempotency-headers/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/imdb/deep-package-path/.fern/metadata.json
+++ b/seed/go-sdk/imdb/deep-package-path/.fern/metadata.json
@@ -7,8 +7,7 @@
     "packagePath": "all/the/way/in/here/please"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller_test.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/retrier.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/imdb/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/imdb/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/imdb/omit-fern-headers/.fern/metadata.json
+++ b/seed/go-sdk/imdb/omit-fern-headers/.fern/metadata.json
@@ -8,8 +8,7 @@
     "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/caller_test.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/retrier.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/imdb/package-path/.fern/metadata.json
+++ b/seed/go-sdk/imdb/package-path/.fern/metadata.json
@@ -7,8 +7,7 @@
     "packagePath": "inhereplease"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/caller_test.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/retrier.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/imdb/with-wiremock-tests/.fern/metadata.json
+++ b/seed/go-sdk/imdb/with-wiremock-tests/.fern/metadata.json
@@ -9,8 +9,7 @@
     "clientConstructorName": "NewIMDBClient"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/caller_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/retrier.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/go-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/inferred-auth-explicit/internal/caller_test.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-explicit/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/go-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/caller_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/go-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/inferred-auth-implicit/internal/caller_test.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/inline-enum-type-name-override/.fern/metadata.json
+++ b/seed/go-sdk/inline-enum-type-name-override/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/inline-enum-type-name-override/internal/caller_test.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/inline-enum-type-name-override/internal/retrier.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/license/.fern/metadata.json
+++ b/seed/go-sdk/license/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/license/internal/caller.go
+++ b/seed/go-sdk/license/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/license/internal/caller.go
+++ b/seed/go-sdk/license/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/license/internal/caller.go
+++ b/seed/go-sdk/license/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/license/internal/caller.go
+++ b/seed/go-sdk/license/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/license/internal/caller.go
+++ b/seed/go-sdk/license/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/license/internal/caller.go
+++ b/seed/go-sdk/license/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/license/internal/caller_test.go
+++ b/seed/go-sdk/license/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/license/internal/retrier.go
+++ b/seed/go-sdk/license/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/literal-user-agent/.fern/metadata.json
+++ b/seed/go-sdk/literal-user-agent/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/literal-user-agent/internal/caller.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/literal-user-agent/internal/caller.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/literal-user-agent/internal/caller.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/literal-user-agent/internal/caller.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/literal-user-agent/internal/caller.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/literal-user-agent/internal/caller.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/literal-user-agent/internal/caller_test.go
+++ b/seed/go-sdk/literal-user-agent/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/literal-user-agent/internal/retrier.go
+++ b/seed/go-sdk/literal-user-agent/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/literal/.fern/metadata.json
+++ b/seed/go-sdk/literal/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/literal/internal/caller.go
+++ b/seed/go-sdk/literal/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/literal/internal/caller.go
+++ b/seed/go-sdk/literal/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/literal/internal/caller.go
+++ b/seed/go-sdk/literal/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/literal/internal/caller.go
+++ b/seed/go-sdk/literal/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/literal/internal/caller.go
+++ b/seed/go-sdk/literal/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/literal/internal/caller.go
+++ b/seed/go-sdk/literal/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/literal/internal/caller_test.go
+++ b/seed/go-sdk/literal/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/literal/internal/retrier.go
+++ b/seed/go-sdk/literal/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/literals-unions/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/literals-unions/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/mixed-case/default-values/.fern/metadata.json
+++ b/seed/go-sdk/mixed-case/default-values/.fern/metadata.json
@@ -7,8 +7,7 @@
     "useDefaultRequestParameterValues": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/mixed-case/default-values/internal/caller.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/mixed-case/default-values/internal/caller.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/mixed-case/default-values/internal/caller.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/mixed-case/default-values/internal/caller.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/mixed-case/default-values/internal/caller.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/mixed-case/default-values/internal/caller.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/mixed-case/default-values/internal/caller_test.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/mixed-case/default-values/internal/retrier.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/mixed-case/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/mixed-case/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/go-sdk/mixed-file-directory/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/mixed-file-directory/internal/caller.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/mixed-file-directory/internal/caller.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/mixed-file-directory/internal/caller.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/mixed-file-directory/internal/caller.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/mixed-file-directory/internal/caller.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/mixed-file-directory/internal/caller.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/mixed-file-directory/internal/caller_test.go
+++ b/seed/go-sdk/mixed-file-directory/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/mixed-file-directory/internal/retrier.go
+++ b/seed/go-sdk/mixed-file-directory/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/multi-content-type-examples/.fern/metadata.json
+++ b/seed/go-sdk/multi-content-type-examples/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multi-content-type-examples/internal/caller.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/multi-content-type-examples/internal/caller.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/multi-content-type-examples/internal/caller.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-content-type-examples/internal/caller.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-content-type-examples/internal/caller.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/multi-content-type-examples/internal/caller.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/multi-content-type-examples/internal/caller_test.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/multi-content-type-examples/internal/retrier.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/go-sdk/multi-line-docs/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multi-line-docs/internal/caller.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/multi-line-docs/internal/caller.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/multi-line-docs/internal/caller.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-line-docs/internal/caller.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-line-docs/internal/caller.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/multi-line-docs/internal/caller.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/multi-line-docs/internal/caller_test.go
+++ b/seed/go-sdk/multi-line-docs/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/multi-line-docs/internal/retrier.go
+++ b/seed/go-sdk/multi-line-docs/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/go-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/multi-url-environment-no-default/internal/caller_test.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/multi-url-environment-no-default/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/go-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/multi-url-environment-reference/internal/caller_test.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/multi-url-environment-reference/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/go-sdk/multi-url-environment/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multi-url-environment/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/multi-url-environment/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/multi-url-environment/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-url-environment/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multi-url-environment/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/multi-url-environment/internal/caller.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/multi-url-environment/internal/caller_test.go
+++ b/seed/go-sdk/multi-url-environment/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/multi-url-environment/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/go-sdk/multiple-request-bodies/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multiple-request-bodies/internal/caller.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/multiple-request-bodies/internal/caller.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/multiple-request-bodies/internal/caller.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multiple-request-bodies/internal/caller.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/multiple-request-bodies/internal/caller.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/multiple-request-bodies/internal/caller.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/multiple-request-bodies/internal/caller_test.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/multiple-request-bodies/internal/retrier.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/no-content-response/.fern/metadata.json
+++ b/seed/go-sdk/no-content-response/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/no-content-response/internal/caller.go
+++ b/seed/go-sdk/no-content-response/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/no-content-response/internal/caller.go
+++ b/seed/go-sdk/no-content-response/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/no-content-response/internal/caller.go
+++ b/seed/go-sdk/no-content-response/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/no-content-response/internal/caller.go
+++ b/seed/go-sdk/no-content-response/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/no-content-response/internal/caller.go
+++ b/seed/go-sdk/no-content-response/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/no-content-response/internal/caller.go
+++ b/seed/go-sdk/no-content-response/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/no-content-response/internal/caller_test.go
+++ b/seed/go-sdk/no-content-response/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/no-content-response/internal/retrier.go
+++ b/seed/go-sdk/no-content-response/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/no-environment/.fern/metadata.json
+++ b/seed/go-sdk/no-environment/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/no-environment/internal/caller.go
+++ b/seed/go-sdk/no-environment/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/no-environment/internal/caller.go
+++ b/seed/go-sdk/no-environment/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/no-environment/internal/caller.go
+++ b/seed/go-sdk/no-environment/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/no-environment/internal/caller.go
+++ b/seed/go-sdk/no-environment/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/no-environment/internal/caller.go
+++ b/seed/go-sdk/no-environment/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/no-environment/internal/caller.go
+++ b/seed/go-sdk/no-environment/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/no-environment/internal/caller_test.go
+++ b/seed/go-sdk/no-environment/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/no-environment/internal/retrier.go
+++ b/seed/go-sdk/no-environment/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/no-retries/.fern/metadata.json
+++ b/seed/go-sdk/no-retries/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/no-retries/internal/caller.go
+++ b/seed/go-sdk/no-retries/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/no-retries/internal/caller.go
+++ b/seed/go-sdk/no-retries/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/no-retries/internal/caller.go
+++ b/seed/go-sdk/no-retries/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/no-retries/internal/caller.go
+++ b/seed/go-sdk/no-retries/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/no-retries/internal/caller.go
+++ b/seed/go-sdk/no-retries/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/no-retries/internal/caller.go
+++ b/seed/go-sdk/no-retries/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/no-retries/internal/caller_test.go
+++ b/seed/go-sdk/no-retries/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/no-retries/internal/retrier.go
+++ b/seed/go-sdk/no-retries/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/null-type/.fern/metadata.json
+++ b/seed/go-sdk/null-type/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/null-type/internal/caller.go
+++ b/seed/go-sdk/null-type/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/null-type/internal/caller.go
+++ b/seed/go-sdk/null-type/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/null-type/internal/caller.go
+++ b/seed/go-sdk/null-type/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/null-type/internal/caller.go
+++ b/seed/go-sdk/null-type/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/null-type/internal/caller.go
+++ b/seed/go-sdk/null-type/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/null-type/internal/caller.go
+++ b/seed/go-sdk/null-type/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/null-type/internal/caller_test.go
+++ b/seed/go-sdk/null-type/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/null-type/internal/retrier.go
+++ b/seed/go-sdk/null-type/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/go-sdk/nullable-allof-extends/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/nullable-allof-extends/internal/caller.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/nullable-allof-extends/internal/caller.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/nullable-allof-extends/internal/caller.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable-allof-extends/internal/caller.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable-allof-extends/internal/caller.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/nullable-allof-extends/internal/caller.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/nullable-allof-extends/internal/caller_test.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/nullable-allof-extends/internal/retrier.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/go-sdk/nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/nullable-optional/internal/caller.go
+++ b/seed/go-sdk/nullable-optional/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/nullable-optional/internal/caller.go
+++ b/seed/go-sdk/nullable-optional/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/nullable-optional/internal/caller.go
+++ b/seed/go-sdk/nullable-optional/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable-optional/internal/caller.go
+++ b/seed/go-sdk/nullable-optional/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable-optional/internal/caller.go
+++ b/seed/go-sdk/nullable-optional/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/nullable-optional/internal/caller.go
+++ b/seed/go-sdk/nullable-optional/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/nullable-optional/internal/caller_test.go
+++ b/seed/go-sdk/nullable-optional/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/nullable-optional/internal/retrier.go
+++ b/seed/go-sdk/nullable-optional/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/.fern/metadata.json
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller_test.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/retrier.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/nullable/.fern/metadata.json
+++ b/seed/go-sdk/nullable/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/nullable/internal/caller.go
+++ b/seed/go-sdk/nullable/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/nullable/internal/caller.go
+++ b/seed/go-sdk/nullable/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/nullable/internal/caller.go
+++ b/seed/go-sdk/nullable/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable/internal/caller.go
+++ b/seed/go-sdk/nullable/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/nullable/internal/caller.go
+++ b/seed/go-sdk/nullable/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/nullable/internal/caller.go
+++ b/seed/go-sdk/nullable/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/nullable/internal/caller_test.go
+++ b/seed/go-sdk/nullable/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/nullable/internal/retrier.go
+++ b/seed/go-sdk/nullable/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-default/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-default/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/go-sdk/oauth-client-credentials/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/oauth-client-credentials/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/oauth-client-credentials/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/oauth-client-credentials/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/oauth-client-credentials/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/oauth-client-credentials/internal/caller.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/oauth-client-credentials/internal/caller_test.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/object/.fern/metadata.json
+++ b/seed/go-sdk/object/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/object/internal/caller.go
+++ b/seed/go-sdk/object/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/object/internal/caller.go
+++ b/seed/go-sdk/object/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/object/internal/caller.go
+++ b/seed/go-sdk/object/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/object/internal/caller.go
+++ b/seed/go-sdk/object/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/object/internal/caller.go
+++ b/seed/go-sdk/object/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/object/internal/caller.go
+++ b/seed/go-sdk/object/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/object/internal/caller_test.go
+++ b/seed/go-sdk/object/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/object/internal/retrier.go
+++ b/seed/go-sdk/object/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/go-sdk/objects-with-imports/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/objects-with-imports/internal/caller.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/objects-with-imports/internal/caller.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/objects-with-imports/internal/caller.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/objects-with-imports/internal/caller.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/objects-with-imports/internal/caller.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/objects-with-imports/internal/caller.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/objects-with-imports/internal/caller_test.go
+++ b/seed/go-sdk/objects-with-imports/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/objects-with-imports/internal/retrier.go
+++ b/seed/go-sdk/objects-with-imports/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/openapi-subtitle/.fern/metadata.json
+++ b/seed/go-sdk/openapi-subtitle/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/openapi-subtitle/internal/caller.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/openapi-subtitle/internal/caller.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/openapi-subtitle/internal/caller.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/openapi-subtitle/internal/caller.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/openapi-subtitle/internal/caller.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/openapi-subtitle/internal/caller.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/openapi-subtitle/internal/caller_test.go
+++ b/seed/go-sdk/openapi-subtitle/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/openapi-subtitle/internal/retrier.go
+++ b/seed/go-sdk/openapi-subtitle/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/optional/.fern/metadata.json
+++ b/seed/go-sdk/optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/optional/internal/caller.go
+++ b/seed/go-sdk/optional/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/optional/internal/caller.go
+++ b/seed/go-sdk/optional/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/optional/internal/caller.go
+++ b/seed/go-sdk/optional/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/optional/internal/caller.go
+++ b/seed/go-sdk/optional/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/optional/internal/caller.go
+++ b/seed/go-sdk/optional/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/optional/internal/caller.go
+++ b/seed/go-sdk/optional/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/optional/internal/caller_test.go
+++ b/seed/go-sdk/optional/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/optional/internal/retrier.go
+++ b/seed/go-sdk/optional/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/package-yml/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/package-yml/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/package-yml/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/package-yml/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/go-sdk/pagination-custom/.fern/metadata.json
@@ -7,8 +7,7 @@
     "customPagerName": "PayrocPager"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/pagination-custom/internal/caller.go
+++ b/seed/go-sdk/pagination-custom/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/pagination-custom/internal/caller.go
+++ b/seed/go-sdk/pagination-custom/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/pagination-custom/internal/caller.go
+++ b/seed/go-sdk/pagination-custom/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/pagination-custom/internal/caller.go
+++ b/seed/go-sdk/pagination-custom/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/pagination-custom/internal/caller.go
+++ b/seed/go-sdk/pagination-custom/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/pagination-custom/internal/caller.go
+++ b/seed/go-sdk/pagination-custom/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/pagination-custom/internal/caller_test.go
+++ b/seed/go-sdk/pagination-custom/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/pagination-custom/internal/retrier.go
+++ b/seed/go-sdk/pagination-custom/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/go-sdk/pagination-uri-path/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/pagination-uri-path/internal/caller.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/pagination-uri-path/internal/caller.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/pagination-uri-path/internal/caller.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/pagination-uri-path/internal/caller.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/pagination-uri-path/internal/caller.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/pagination-uri-path/internal/caller.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/pagination-uri-path/internal/caller_test.go
+++ b/seed/go-sdk/pagination-uri-path/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/pagination-uri-path/internal/retrier.go
+++ b/seed/go-sdk/pagination-uri-path/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/pagination/.fern/metadata.json
+++ b/seed/go-sdk/pagination/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/pagination/internal/caller.go
+++ b/seed/go-sdk/pagination/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/pagination/internal/caller.go
+++ b/seed/go-sdk/pagination/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/pagination/internal/caller.go
+++ b/seed/go-sdk/pagination/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/pagination/internal/caller.go
+++ b/seed/go-sdk/pagination/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/pagination/internal/caller.go
+++ b/seed/go-sdk/pagination/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/pagination/internal/caller.go
+++ b/seed/go-sdk/pagination/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/pagination/internal/caller_test.go
+++ b/seed/go-sdk/pagination/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/pagination/internal/retrier.go
+++ b/seed/go-sdk/pagination/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/path-parameters/package-name/.fern/metadata.json
+++ b/seed/go-sdk/path-parameters/package-name/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/path-parameters/package-name/internal/caller.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/path-parameters/package-name/internal/caller.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/path-parameters/package-name/internal/caller.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/path-parameters/package-name/internal/caller.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/path-parameters/package-name/internal/caller.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/path-parameters/package-name/internal/caller.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/path-parameters/package-name/internal/caller_test.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/path-parameters/package-name/internal/retrier.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/path-parameters/v0/.fern/metadata.json
+++ b/seed/go-sdk/path-parameters/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/path-parameters/v0/internal/caller.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/path-parameters/v0/internal/caller.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/path-parameters/v0/internal/caller.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/path-parameters/v0/internal/caller.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/path-parameters/v0/internal/caller.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/path-parameters/v0/internal/caller.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/path-parameters/v0/internal/caller_test.go
+++ b/seed/go-sdk/path-parameters/v0/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/path-parameters/v0/internal/retrier.go
+++ b/seed/go-sdk/path-parameters/v0/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/plain-text/.fern/metadata.json
+++ b/seed/go-sdk/plain-text/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/plain-text/internal/caller.go
+++ b/seed/go-sdk/plain-text/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/plain-text/internal/caller.go
+++ b/seed/go-sdk/plain-text/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/plain-text/internal/caller.go
+++ b/seed/go-sdk/plain-text/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/plain-text/internal/caller.go
+++ b/seed/go-sdk/plain-text/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/plain-text/internal/caller.go
+++ b/seed/go-sdk/plain-text/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/plain-text/internal/caller.go
+++ b/seed/go-sdk/plain-text/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/plain-text/internal/caller_test.go
+++ b/seed/go-sdk/plain-text/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/plain-text/internal/retrier.go
+++ b/seed/go-sdk/plain-text/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/property-access/.fern/metadata.json
+++ b/seed/go-sdk/property-access/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/property-access/internal/caller.go
+++ b/seed/go-sdk/property-access/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/property-access/internal/caller.go
+++ b/seed/go-sdk/property-access/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/property-access/internal/caller.go
+++ b/seed/go-sdk/property-access/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/property-access/internal/caller.go
+++ b/seed/go-sdk/property-access/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/property-access/internal/caller.go
+++ b/seed/go-sdk/property-access/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/property-access/internal/caller.go
+++ b/seed/go-sdk/property-access/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/property-access/internal/caller_test.go
+++ b/seed/go-sdk/property-access/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/property-access/internal/retrier.go
+++ b/seed/go-sdk/property-access/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/public-object/.fern/metadata.json
+++ b/seed/go-sdk/public-object/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/public-object/internal/caller.go
+++ b/seed/go-sdk/public-object/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/public-object/internal/caller.go
+++ b/seed/go-sdk/public-object/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/public-object/internal/caller.go
+++ b/seed/go-sdk/public-object/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/public-object/internal/caller.go
+++ b/seed/go-sdk/public-object/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/public-object/internal/caller.go
+++ b/seed/go-sdk/public-object/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/public-object/internal/caller.go
+++ b/seed/go-sdk/public-object/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/public-object/internal/caller_test.go
+++ b/seed/go-sdk/public-object/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/public-object/internal/retrier.go
+++ b/seed/go-sdk/public-object/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/go-sdk/query-param-name-conflict/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/query-param-name-conflict/internal/caller.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/query-param-name-conflict/internal/caller.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/query-param-name-conflict/internal/caller.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-param-name-conflict/internal/caller.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-param-name-conflict/internal/caller.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/query-param-name-conflict/internal/caller.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/query-param-name-conflict/internal/caller_test.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/query-param-name-conflict/internal/retrier.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller_test.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/retrier.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/go-sdk/query-parameters-openapi/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/query-parameters-openapi/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/query-parameters-openapi/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/query-parameters-openapi/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-parameters-openapi/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-parameters-openapi/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/query-parameters-openapi/internal/caller.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/query-parameters-openapi/internal/caller_test.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/query-parameters-openapi/internal/retrier.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/query-parameters/.fern/metadata.json
+++ b/seed/go-sdk/query-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/query-parameters/internal/caller.go
+++ b/seed/go-sdk/query-parameters/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/query-parameters/internal/caller.go
+++ b/seed/go-sdk/query-parameters/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/query-parameters/internal/caller.go
+++ b/seed/go-sdk/query-parameters/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-parameters/internal/caller.go
+++ b/seed/go-sdk/query-parameters/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/query-parameters/internal/caller.go
+++ b/seed/go-sdk/query-parameters/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/query-parameters/internal/caller.go
+++ b/seed/go-sdk/query-parameters/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/query-parameters/internal/caller_test.go
+++ b/seed/go-sdk/query-parameters/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/query-parameters/internal/retrier.go
+++ b/seed/go-sdk/query-parameters/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/required-nullable/.fern/metadata.json
+++ b/seed/go-sdk/required-nullable/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/required-nullable/internal/caller.go
+++ b/seed/go-sdk/required-nullable/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/required-nullable/internal/caller.go
+++ b/seed/go-sdk/required-nullable/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/required-nullable/internal/caller.go
+++ b/seed/go-sdk/required-nullable/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/required-nullable/internal/caller.go
+++ b/seed/go-sdk/required-nullable/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/required-nullable/internal/caller.go
+++ b/seed/go-sdk/required-nullable/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/required-nullable/internal/caller.go
+++ b/seed/go-sdk/required-nullable/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/required-nullable/internal/caller_test.go
+++ b/seed/go-sdk/required-nullable/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/required-nullable/internal/retrier.go
+++ b/seed/go-sdk/required-nullable/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/go-sdk/reserved-keywords/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/reserved-keywords/internal/caller.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/reserved-keywords/internal/caller.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/reserved-keywords/internal/caller.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/reserved-keywords/internal/caller.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/reserved-keywords/internal/caller.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/reserved-keywords/internal/caller.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/reserved-keywords/internal/caller_test.go
+++ b/seed/go-sdk/reserved-keywords/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/reserved-keywords/internal/retrier.go
+++ b/seed/go-sdk/reserved-keywords/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/response-property/.fern/metadata.json
+++ b/seed/go-sdk/response-property/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/response-property/internal/caller.go
+++ b/seed/go-sdk/response-property/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/response-property/internal/caller.go
+++ b/seed/go-sdk/response-property/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/response-property/internal/caller.go
+++ b/seed/go-sdk/response-property/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/response-property/internal/caller.go
+++ b/seed/go-sdk/response-property/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/response-property/internal/caller.go
+++ b/seed/go-sdk/response-property/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/response-property/internal/caller.go
+++ b/seed/go-sdk/response-property/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/response-property/internal/caller_test.go
+++ b/seed/go-sdk/response-property/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/response-property/internal/retrier.go
+++ b/seed/go-sdk/response-property/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/go-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/schemaless-request-body-examples/internal/caller_test.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/schemaless-request-body-examples/internal/retrier.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/.fern/metadata.json
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller_test.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/streamer.go
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/streamer.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/streamer.go
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/.fern/metadata.json
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller_test.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/streamer.go
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/streamer.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/streamer.go
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/seed/go-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/go-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/server-sent-events-resumable/internal/caller_test.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/server-sent-events-resumable/internal/retrier.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/server-sent-events-resumable/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/streamer.go
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/seed/go-sdk/server-sent-events-resumable/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/streamer.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/seed/go-sdk/server-sent-events-resumable/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/streamer.go
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/seed/go-sdk/server-sent-events/with-wire-tests/.fern/metadata.json
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller_test.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/streamer.go
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/streamer.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/streamer.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/streamer.go
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/seed/go-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/go-sdk/server-url-templating/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/server-url-templating/internal/caller.go
+++ b/seed/go-sdk/server-url-templating/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/server-url-templating/internal/caller.go
+++ b/seed/go-sdk/server-url-templating/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/server-url-templating/internal/caller.go
+++ b/seed/go-sdk/server-url-templating/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-url-templating/internal/caller.go
+++ b/seed/go-sdk/server-url-templating/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/server-url-templating/internal/caller.go
+++ b/seed/go-sdk/server-url-templating/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/server-url-templating/internal/caller.go
+++ b/seed/go-sdk/server-url-templating/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/server-url-templating/internal/caller_test.go
+++ b/seed/go-sdk/server-url-templating/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/server-url-templating/internal/retrier.go
+++ b/seed/go-sdk/server-url-templating/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/simple-api/.fern/metadata.json
+++ b/seed/go-sdk/simple-api/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/simple-api/internal/caller.go
+++ b/seed/go-sdk/simple-api/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/simple-api/internal/caller.go
+++ b/seed/go-sdk/simple-api/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/simple-api/internal/caller.go
+++ b/seed/go-sdk/simple-api/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/simple-api/internal/caller.go
+++ b/seed/go-sdk/simple-api/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/simple-api/internal/caller.go
+++ b/seed/go-sdk/simple-api/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/simple-api/internal/caller.go
+++ b/seed/go-sdk/simple-api/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/simple-api/internal/caller_test.go
+++ b/seed/go-sdk/simple-api/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/simple-api/internal/retrier.go
+++ b/seed/go-sdk/simple-api/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/go-sdk/simple-fhir/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/simple-fhir/internal/caller.go
+++ b/seed/go-sdk/simple-fhir/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/simple-fhir/internal/caller.go
+++ b/seed/go-sdk/simple-fhir/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/simple-fhir/internal/caller.go
+++ b/seed/go-sdk/simple-fhir/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/simple-fhir/internal/caller.go
+++ b/seed/go-sdk/simple-fhir/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/simple-fhir/internal/caller.go
+++ b/seed/go-sdk/simple-fhir/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/simple-fhir/internal/caller.go
+++ b/seed/go-sdk/simple-fhir/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/simple-fhir/internal/caller_test.go
+++ b/seed/go-sdk/simple-fhir/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/simple-fhir/internal/retrier.go
+++ b/seed/go-sdk/simple-fhir/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/go-sdk/single-url-environment-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/single-url-environment-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/single-url-environment-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/single-url-environment-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/single-url-environment-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/single-url-environment-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/single-url-environment-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/single-url-environment-default/internal/caller_test.go
+++ b/seed/go-sdk/single-url-environment-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/single-url-environment-default/internal/retrier.go
+++ b/seed/go-sdk/single-url-environment-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/go-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/single-url-environment-no-default/internal/caller_test.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/single-url-environment-no-default/internal/retrier.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/go-sdk/streaming-parameter/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/streaming-parameter/internal/caller.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/streaming-parameter/internal/caller.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/streaming-parameter/internal/caller.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/streaming-parameter/internal/caller.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/streaming-parameter/internal/caller.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/streaming-parameter/internal/caller.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/streaming-parameter/internal/caller_test.go
+++ b/seed/go-sdk/streaming-parameter/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/streaming-parameter/internal/retrier.go
+++ b/seed/go-sdk/streaming-parameter/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/streaming-parameter/internal/streamer.go
+++ b/seed/go-sdk/streaming-parameter/internal/streamer.go
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/seed/go-sdk/streaming-parameter/internal/streamer.go
+++ b/seed/go-sdk/streaming-parameter/internal/streamer.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/seed/go-sdk/streaming-parameter/internal/streamer.go
+++ b/seed/go-sdk/streaming-parameter/internal/streamer.go
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/seed/go-sdk/streaming/.fern/metadata.json
+++ b/seed/go-sdk/streaming/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "v2.0.0",
-  "ciProvider": "github",
   "sdkVersion": "v2.0.0"
 }

--- a/seed/go-sdk/streaming/internal/caller.go
+++ b/seed/go-sdk/streaming/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/streaming/internal/caller.go
+++ b/seed/go-sdk/streaming/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/streaming/internal/caller.go
+++ b/seed/go-sdk/streaming/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/streaming/internal/caller.go
+++ b/seed/go-sdk/streaming/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/streaming/internal/caller.go
+++ b/seed/go-sdk/streaming/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/streaming/internal/caller.go
+++ b/seed/go-sdk/streaming/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/streaming/internal/caller_test.go
+++ b/seed/go-sdk/streaming/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/streaming/internal/retrier.go
+++ b/seed/go-sdk/streaming/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/streaming/internal/streamer.go
+++ b/seed/go-sdk/streaming/internal/streamer.go
@@ -134,6 +134,11 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
+	if err := decompressResponse(resp); err != nil {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, nil, err
+	}
+
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
 	if err := ctx.Err(); err != nil {

--- a/seed/go-sdk/streaming/internal/streamer.go
+++ b/seed/go-sdk/streaming/internal/streamer.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -139,9 +140,15 @@ func (s *Streamer[T]) streamOnce(
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
-	// The response is handed off to the stream, so the (possibly wrapped)
-	// body must replace resp.Body; closing it also closes the original body.
-	resp.Body = body
+	if body != io.Reader(resp.Body) {
+		// The response is handed off to the stream, which reads and closes
+		// resp.Body, so the decompressing reader must replace it while
+		// preserving the original body's Close.
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{body, resp.Body}
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.

--- a/seed/go-sdk/streaming/internal/streamer.go
+++ b/seed/go-sdk/streaming/internal/streamer.go
@@ -134,10 +134,14 @@ func (s *Streamer[T]) streamOnce(
 		return nil, nil, err
 	}
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, nil, err
 	}
+	// The response is handed off to the stream, so the (possibly wrapped)
+	// body must replace resp.Body; closing it also closes the original body.
+	resp.Body = body
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -148,7 +152,7 @@ func (s *Streamer[T]) streamOnce(
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
-		return nil, nil, decodeError(resp, params.ErrorDecoder)
+		return nil, nil, decodeError(resp, resp.Body, params.ErrorDecoder)
 	}
 
 	var opts []core.StreamOption

--- a/seed/go-sdk/trace/.fern/metadata.json
+++ b/seed/go-sdk/trace/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/trace/internal/caller.go
+++ b/seed/go-sdk/trace/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/trace/internal/caller.go
+++ b/seed/go-sdk/trace/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/trace/internal/caller.go
+++ b/seed/go-sdk/trace/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/trace/internal/caller.go
+++ b/seed/go-sdk/trace/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/trace/internal/caller.go
+++ b/seed/go-sdk/trace/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/trace/internal/caller.go
+++ b/seed/go-sdk/trace/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/trace/internal/caller_test.go
+++ b/seed/go-sdk/trace/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/trace/internal/retrier.go
+++ b/seed/go-sdk/trace/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller_test.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/retrier.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/undiscriminated-unions/v0/.fern/metadata.json
+++ b/seed/go-sdk/undiscriminated-unions/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/caller_test.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/retrier.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/go-sdk/union-query-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/union-query-parameters/internal/caller.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/union-query-parameters/internal/caller.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/union-query-parameters/internal/caller.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/union-query-parameters/internal/caller.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/union-query-parameters/internal/caller.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/union-query-parameters/internal/caller.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/union-query-parameters/internal/caller_test.go
+++ b/seed/go-sdk/union-query-parameters/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/union-query-parameters/internal/retrier.go
+++ b/seed/go-sdk/union-query-parameters/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/go-sdk/unions-with-local-date/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions-with-local-date/internal/caller.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/unions-with-local-date/internal/caller.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/unions-with-local-date/internal/caller.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions-with-local-date/internal/caller.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions-with-local-date/internal/caller.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/unions-with-local-date/internal/caller.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/unions-with-local-date/internal/caller_test.go
+++ b/seed/go-sdk/unions-with-local-date/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/unions-with-local-date/internal/retrier.go
+++ b/seed/go-sdk/unions-with-local-date/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/unions/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/unions/no-custom-config/internal/caller.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/unions/no-custom-config/internal/caller_test.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/unions/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/unions/package-name/.fern/metadata.json
+++ b/seed/go-sdk/unions/package-name/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions/package-name/internal/caller.go
+++ b/seed/go-sdk/unions/package-name/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/unions/package-name/internal/caller.go
+++ b/seed/go-sdk/unions/package-name/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/unions/package-name/internal/caller.go
+++ b/seed/go-sdk/unions/package-name/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions/package-name/internal/caller.go
+++ b/seed/go-sdk/unions/package-name/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions/package-name/internal/caller.go
+++ b/seed/go-sdk/unions/package-name/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/unions/package-name/internal/caller.go
+++ b/seed/go-sdk/unions/package-name/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/unions/package-name/internal/caller_test.go
+++ b/seed/go-sdk/unions/package-name/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/unions/package-name/internal/retrier.go
+++ b/seed/go-sdk/unions/package-name/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/unions/v0/.fern/metadata.json
+++ b/seed/go-sdk/unions/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions/v0/internal/caller.go
+++ b/seed/go-sdk/unions/v0/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/unions/v0/internal/caller.go
+++ b/seed/go-sdk/unions/v0/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/unions/v0/internal/caller.go
+++ b/seed/go-sdk/unions/v0/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions/v0/internal/caller.go
+++ b/seed/go-sdk/unions/v0/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unions/v0/internal/caller.go
+++ b/seed/go-sdk/unions/v0/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/unions/v0/internal/caller.go
+++ b/seed/go-sdk/unions/v0/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/unions/v0/internal/caller_test.go
+++ b/seed/go-sdk/unions/v0/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/unions/v0/internal/retrier.go
+++ b/seed/go-sdk/unions/v0/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/unknown/.fern/metadata.json
+++ b/seed/go-sdk/unknown/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unknown/internal/caller.go
+++ b/seed/go-sdk/unknown/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/unknown/internal/caller.go
+++ b/seed/go-sdk/unknown/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/unknown/internal/caller.go
+++ b/seed/go-sdk/unknown/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unknown/internal/caller.go
+++ b/seed/go-sdk/unknown/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/unknown/internal/caller.go
+++ b/seed/go-sdk/unknown/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/unknown/internal/caller.go
+++ b/seed/go-sdk/unknown/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/unknown/internal/caller_test.go
+++ b/seed/go-sdk/unknown/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/unknown/internal/retrier.go
+++ b/seed/go-sdk/unknown/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/go-sdk/url-form-encoded/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/url-form-encoded/internal/caller.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/url-form-encoded/internal/caller.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/url-form-encoded/internal/caller.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/url-form-encoded/internal/caller.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/url-form-encoded/internal/caller.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/url-form-encoded/internal/caller.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/url-form-encoded/internal/caller_test.go
+++ b/seed/go-sdk/url-form-encoded/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/url-form-encoded/internal/retrier.go
+++ b/seed/go-sdk/url-form-encoded/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/validation/.fern/metadata.json
+++ b/seed/go-sdk/validation/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/validation/internal/caller.go
+++ b/seed/go-sdk/validation/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/validation/internal/caller.go
+++ b/seed/go-sdk/validation/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/validation/internal/caller.go
+++ b/seed/go-sdk/validation/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/validation/internal/caller.go
+++ b/seed/go-sdk/validation/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/validation/internal/caller.go
+++ b/seed/go-sdk/validation/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/validation/internal/caller.go
+++ b/seed/go-sdk/validation/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/validation/internal/caller_test.go
+++ b/seed/go-sdk/validation/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/validation/internal/retrier.go
+++ b/seed/go-sdk/validation/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/variables/.fern/metadata.json
+++ b/seed/go-sdk/variables/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/variables/internal/caller.go
+++ b/seed/go-sdk/variables/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/variables/internal/caller.go
+++ b/seed/go-sdk/variables/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/variables/internal/caller.go
+++ b/seed/go-sdk/variables/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/variables/internal/caller.go
+++ b/seed/go-sdk/variables/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/variables/internal/caller.go
+++ b/seed/go-sdk/variables/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/variables/internal/caller.go
+++ b/seed/go-sdk/variables/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/variables/internal/caller_test.go
+++ b/seed/go-sdk/variables/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/variables/internal/retrier.go
+++ b/seed/go-sdk/variables/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/version-no-default/.fern/metadata.json
+++ b/seed/go-sdk/version-no-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/version-no-default/internal/caller.go
+++ b/seed/go-sdk/version-no-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/version-no-default/internal/caller.go
+++ b/seed/go-sdk/version-no-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/version-no-default/internal/caller.go
+++ b/seed/go-sdk/version-no-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/version-no-default/internal/caller.go
+++ b/seed/go-sdk/version-no-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/version-no-default/internal/caller.go
+++ b/seed/go-sdk/version-no-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/version-no-default/internal/caller.go
+++ b/seed/go-sdk/version-no-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/version-no-default/internal/caller_test.go
+++ b/seed/go-sdk/version-no-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/version-no-default/internal/retrier.go
+++ b/seed/go-sdk/version-no-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/version/.fern/metadata.json
+++ b/seed/go-sdk/version/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/version/internal/caller.go
+++ b/seed/go-sdk/version/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/version/internal/caller.go
+++ b/seed/go-sdk/version/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/version/internal/caller.go
+++ b/seed/go-sdk/version/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/version/internal/caller.go
+++ b/seed/go-sdk/version/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/version/internal/caller.go
+++ b/seed/go-sdk/version/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/version/internal/caller.go
+++ b/seed/go-sdk/version/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/version/internal/caller_test.go
+++ b/seed/go-sdk/version/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/version/internal/retrier.go
+++ b/seed/go-sdk/version/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/go-sdk/webhook-audience/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/webhook-audience/internal/caller.go
+++ b/seed/go-sdk/webhook-audience/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/webhook-audience/internal/caller.go
+++ b/seed/go-sdk/webhook-audience/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/webhook-audience/internal/caller.go
+++ b/seed/go-sdk/webhook-audience/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/webhook-audience/internal/caller.go
+++ b/seed/go-sdk/webhook-audience/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/webhook-audience/internal/caller.go
+++ b/seed/go-sdk/webhook-audience/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/webhook-audience/internal/caller.go
+++ b/seed/go-sdk/webhook-audience/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/webhook-audience/internal/caller_test.go
+++ b/seed/go-sdk/webhook-audience/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/webhook-audience/internal/retrier.go
+++ b/seed/go-sdk/webhook-audience/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/webhooks/.fern/metadata.json
+++ b/seed/go-sdk/webhooks/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/webhooks/internal/caller.go
+++ b/seed/go-sdk/webhooks/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/webhooks/internal/caller.go
+++ b/seed/go-sdk/webhooks/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/webhooks/internal/caller.go
+++ b/seed/go-sdk/webhooks/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/webhooks/internal/caller.go
+++ b/seed/go-sdk/webhooks/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/webhooks/internal/caller.go
+++ b/seed/go-sdk/webhooks/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/webhooks/internal/caller.go
+++ b/seed/go-sdk/webhooks/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/webhooks/internal/caller_test.go
+++ b/seed/go-sdk/webhooks/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/webhooks/internal/retrier.go
+++ b/seed/go-sdk/webhooks/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/go-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/websocket-bearer-auth/internal/caller_test.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/websocket-bearer-auth/internal/retrier.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/go-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/websocket-inferred-auth/internal/caller_test.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/websocket-inferred-auth/internal/retrier.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/go-sdk/websocket-multi-url/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/websocket-multi-url/internal/caller.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/websocket-multi-url/internal/caller.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/websocket-multi-url/internal/caller.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket-multi-url/internal/caller.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket-multi-url/internal/caller.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/websocket-multi-url/internal/caller.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/websocket-multi-url/internal/caller_test.go
+++ b/seed/go-sdk/websocket-multi-url/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/websocket-multi-url/internal/retrier.go
+++ b/seed/go-sdk/websocket-multi-url/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/websocket/.fern/metadata.json
+++ b/seed/go-sdk/websocket/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/websocket/internal/caller.go
+++ b/seed/go-sdk/websocket/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/websocket/internal/caller.go
+++ b/seed/go-sdk/websocket/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/websocket/internal/caller.go
+++ b/seed/go-sdk/websocket/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket/internal/caller.go
+++ b/seed/go-sdk/websocket/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/websocket/internal/caller.go
+++ b/seed/go-sdk/websocket/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/websocket/internal/caller.go
+++ b/seed/go-sdk/websocket/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/websocket/internal/caller_test.go
+++ b/seed/go-sdk/websocket/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/websocket/internal/retrier.go
+++ b/seed/go-sdk/websocket/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/go-sdk/x-fern-default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/x-fern-default/internal/caller.go
+++ b/seed/go-sdk/x-fern-default/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/x-fern-default/internal/caller.go
+++ b/seed/go-sdk/x-fern-default/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/x-fern-default/internal/caller.go
+++ b/seed/go-sdk/x-fern-default/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/x-fern-default/internal/caller.go
+++ b/seed/go-sdk/x-fern-default/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/x-fern-default/internal/caller.go
+++ b/seed/go-sdk/x-fern-default/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/x-fern-default/internal/caller.go
+++ b/seed/go-sdk/x-fern-default/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/x-fern-default/internal/caller_test.go
+++ b/seed/go-sdk/x-fern-default/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/x-fern-default/internal/retrier.go
+++ b/seed/go-sdk/x-fern-default/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 

--- a/seed/go-sdk/x-fern-global-parameters/.fern/metadata.json
+++ b/seed/go-sdk/x-fern-global-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,10 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
+
+	if err := decompressResponse(resp); err != nil {
+		return nil, err
+	}
 
 	// Check if the call was cancelled before we return the error
 	// associated with the call and/or unmarshal the response data.
@@ -261,6 +266,52 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 		values.Set(key, fmt.Sprintf("%v", val))
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// decompressResponse wraps the response body with a gzip reader when the
+// server responds with a gzip-encoded body that the underlying HTTP client
+// did not transparently decompress (e.g. when an Accept-Encoding header is
+// set explicitly on the request).
+func decompressResponse(resp *http.Response) error {
+	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
+		return nil
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return nil
+	}
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		if err == io.EOF {
+			// The response body is empty, so there is nothing to decompress.
+			return nil
+		}
+		return err
+	}
+	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+// gzipReadCloser reads decompressed content from the gzip reader and
+// closes both the gzip reader and the underlying response body.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	body       io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzipReader.Close()
+	if bodyErr := g.body.Close(); bodyErr != nil {
+		return bodyErr
+	}
+	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response. Note that

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller.go
@@ -109,7 +109,8 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	// Close the response body after we're done.
 	defer func() { _ = resp.Body.Close() }()
 
-	if err := decompressResponse(resp); err != nil {
+	body, err := decompressedResponseBody(resp)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,15 +121,15 @@ func (c *Caller) Call(ctx context.Context, params *CallParams) (*CallResponse, e
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, decodeError(resp, params.ErrorDecoder)
+		return nil, decodeError(resp, body, params.ErrorDecoder)
 	}
 
 	// Mutate the response parameter in-place.
 	if params.Response != nil {
 		if writer, ok := params.Response.(io.Writer); ok {
-			_, err = io.Copy(writer, resp.Body)
+			_, err = io.Copy(writer, body)
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(params.Response)
+			err = json.NewDecoder(body).Decode(params.Response)
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -268,31 +269,27 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 	return strings.NewReader(values.Encode()), nil
 }
 
-// decompressResponse wraps the response body with a gzip reader when the
-// server responds with a gzip-encoded body that the underlying HTTP client
-// did not transparently decompress (e.g. when an Accept-Encoding header is
-// set explicitly on the request).
-func decompressResponse(resp *http.Response) error {
+// decompressedResponseBody returns a reader for the response body, wrapped
+// with a gzip reader when the server responds with a gzip-encoded body that
+// the underlying HTTP client did not transparently decompress (e.g. when an
+// Accept-Encoding header is set explicitly on the request). The response is
+// not modified; closing the returned body also closes resp.Body.
+func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
-		return nil
+		return resp.Body, nil
 	}
 	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
-		return nil
+		return resp.Body, nil
 	}
 	gzipReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return nil
+			return resp.Body, nil
 		}
-		return err
+		return nil, err
 	}
-	resp.Body = &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}
-	resp.Header.Del("Content-Encoding")
-	resp.Header.Del("Content-Length")
-	resp.ContentLength = -1
-	resp.Uncompressed = true
-	return nil
+	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
@@ -328,19 +325,20 @@ func (g *gzipReadCloser) Close() error {
 	return gzipErr
 }
 
-// decodeError decodes the error from the given HTTP response. Note that
-// it's the caller's responsibility to close the response body.
-func decodeError(response *http.Response, errorDecoder ErrorDecoder) error {
+// decodeError decodes the error from the given HTTP response, reading the
+// error content from the given body. Note that it's the caller's
+// responsibility to close the response body.
+func decodeError(response *http.Response, body io.Reader, errorDecoder ErrorDecoder) error {
 	if errorDecoder != nil {
 		// This endpoint has custom errors, so we'll
 		// attempt to unmarshal the error into a structured
 		// type based on the status code.
-		return errorDecoder(response.StatusCode, response.Header, response.Body)
+		return errorDecoder(response.StatusCode, response.Header, body)
 	}
 	// This endpoint doesn't have any custom error
 	// types, so we just read the body as-is, and
 	// put it into a normal error.
-	bytes, err := io.ReadAll(response.Body)
+	bytes, err := io.ReadAll(body)
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller.go
@@ -289,30 +289,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 		}
 		return nil, err
 	}
-	return &gunzipReader{gzipReader: gzipReader}, nil
-}
-
-// maxDecompressedBodySize caps the number of decompressed bytes read from a
-// gzip response body to guard against decompression bombs.
-const maxDecompressedBodySize = 1 << 30 // 1 GiB
-
-// gunzipReader reads decompressed content from the gzip reader, limiting
-// the total number of decompressed bytes to maxDecompressedBodySize.
-type gunzipReader struct {
-	gzipReader *gzip.Reader
-	read       int64
-}
-
-func (g *gunzipReader) Read(p []byte) (int, error) {
-	if g.read >= maxDecompressedBodySize {
-		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	n, err := g.gzipReader.Read(p)
-	g.read += int64(n)
-	if err == nil && g.read > maxDecompressedBodySize {
-		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
-	}
-	return n, err
+	return gzipReader, nil
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller.go
@@ -273,8 +273,8 @@ func newFormURLEncodedRequestBody(request interface{}, bodyProperties map[string
 // with a gzip reader when the server responds with a gzip-encoded body that
 // the underlying HTTP client did not transparently decompress (e.g. when an
 // Accept-Encoding header is set explicitly on the request). The response is
-// not modified; closing the returned body also closes resp.Body.
-func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
+// not modified; closing resp.Body remains the caller's responsibility.
+func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if resp.Uncompressed || resp.Body == nil || resp.Body == http.NoBody {
 		return resp.Body, nil
 	}
@@ -289,23 +289,21 @@ func decompressedResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &gzipReadCloser{gzipReader: gzipReader, body: resp.Body}, nil
+	return &gunzipReader{gzipReader: gzipReader}, nil
 }
 
 // maxDecompressedBodySize caps the number of decompressed bytes read from a
 // gzip response body to guard against decompression bombs.
 const maxDecompressedBodySize = 1 << 30 // 1 GiB
 
-// gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body. It limits
+// gunzipReader reads decompressed content from the gzip reader, limiting
 // the total number of decompressed bytes to maxDecompressedBodySize.
-type gzipReadCloser struct {
+type gunzipReader struct {
 	gzipReader *gzip.Reader
-	body       io.ReadCloser
 	read       int64
 }
 
-func (g *gzipReadCloser) Read(p []byte) (int, error) {
+func (g *gunzipReader) Read(p []byte) (int, error) {
 	if g.read >= maxDecompressedBodySize {
 		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
@@ -315,14 +313,6 @@ func (g *gzipReadCloser) Read(p []byte) (int, error) {
 		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
 	}
 	return n, err
-}
-
-func (g *gzipReadCloser) Close() error {
-	gzipErr := g.gzipReader.Close()
-	if bodyErr := g.body.Close(); bodyErr != nil {
-		return bodyErr
-	}
-	return gzipErr
 }
 
 // decodeError decodes the error from the given HTTP response, reading the

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller.go
@@ -295,15 +295,29 @@ func decompressResponse(resp *http.Response) error {
 	return nil
 }
 
+// maxDecompressedBodySize caps the number of decompressed bytes read from a
+// gzip response body to guard against decompression bombs.
+const maxDecompressedBodySize = 1 << 30 // 1 GiB
+
 // gzipReadCloser reads decompressed content from the gzip reader and
-// closes both the gzip reader and the underlying response body.
+// closes both the gzip reader and the underlying response body. It limits
+// the total number of decompressed bytes to maxDecompressedBodySize.
 type gzipReadCloser struct {
 	gzipReader *gzip.Reader
 	body       io.ReadCloser
+	read       int64
 }
 
 func (g *gzipReadCloser) Read(p []byte) (int, error) {
-	return g.gzipReader.Read(p)
+	if g.read >= maxDecompressedBodySize {
+		return 0, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	n, err := g.gzipReader.Read(p)
+	g.read += int64(n)
+	if err == nil && g.read > maxDecompressedBodySize {
+		return n, fmt.Errorf("decompressed response body exceeds %d bytes", int64(maxDecompressedBodySize))
+	}
+	return n, err
 }
 
 func (g *gzipReadCloser) Close() error {

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller.go
@@ -285,7 +285,7 @@ func decompressedResponseBody(resp *http.Response) (io.Reader, error) {
 	if err != nil {
 		if err == io.EOF {
 			// The response body is empty, so there is nothing to decompress.
-			return resp.Body, nil
+			return http.NoBody, nil
 		}
 		return nil, err
 	}

--- a/seed/go-sdk/x-fern-global-parameters/internal/caller_test.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/caller_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -237,6 +238,41 @@ func TestCall(t *testing.T) {
 			assert.Equal(t, test.wantResponse, response)
 		})
 	}
+}
+
+func TestCallWithGzipResponse(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("Content-Type", "application/json")
+			gzipWriter := gzip.NewWriter(w)
+			_, err := gzipWriter.Write([]byte(`{"id": "123"}`))
+			require.NoError(t, err)
+			require.NoError(t, gzipWriter.Close())
+		}),
+	)
+	defer server.Close()
+
+	caller := NewCaller(
+		&CallerParams{
+			Client: server.Client(),
+		},
+	)
+	var response *InternalTestResponse
+	_, err := caller.Call(
+		context.Background(),
+		&CallParams{
+			URL:    server.URL,
+			Method: http.MethodGet,
+			Headers: http.Header{
+				"Accept-Encoding": []string{"gzip"},
+			},
+			Response: &response,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, &InternalTestResponse{Id: "123"}, response)
 }
 
 func TestMergeHeaders(t *testing.T) {

--- a/seed/go-sdk/x-fern-global-parameters/internal/retrier.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/retrier.go
@@ -151,7 +151,7 @@ func (r *Retrier) run(
 			errorDecoder,
 			maxRetryAttempts,
 			retryAttempt+1,
-			decodeError(response, errorDecoder),
+			decodeError(response, response.Body, errorDecoder),
 		)
 	}
 


### PR DESCRIPTION
## Description

### Why is this needed?
Fern generators never add `Accept-Encoding` themselves — but when an API definition/OpenAPI spec declares `Accept-Encoding: gzip` as a request header, the generated Go SDK sets it explicitly on every request. The request goes through fine and the server (correctly) responds with a gzip-compressed body (`Content-Encoding: gzip`).

The problem: Go's `net/http` transport only performs transparent gzip decompression **when it added the `Accept-Encoding` header itself**. If the caller sets it explicitly, the transport intentionally skips decompression (see the `Transport.DisableCompression` docs: *"if the user explicitly requested gzip it is not automatically uncompressed"*). The SDK then tries to JSON-deserialize raw gzip bytes and fails at runtime with a parse error.

### How this PR fixes it
The generated SDK core now decompresses the body itself whenever the **response** has `Content-Encoding: gzip` and the transport did not already decode it (`resp.Uncompressed == false`). Decompression is driven purely by the response header, so:
- uncompressed responses pass through untouched
- responses already decoded by the transport (the default no-explicit-header path) are not double-decompressed

## Changes Made
- `caller.go_`: new `decompressResponse(resp)` helper — wraps `resp.Body` in a `gzip.Reader` when `Content-Encoding: gzip` is present and not already handled by the transport; strips `Content-Encoding`/`Content-Length` headers and sets `resp.Uncompressed = true`. Empty bodies (`io.EOF` from `gzip.NewReader`) are passed through untouched.
- `caller.go_`: `gzipReadCloser` closes both the gzip reader and the underlying body, and caps total decompressed bytes at `maxDecompressedBodySize` (1 GiB) to guard against gzip decompression bombs (per security review).
- `streamer.go_`: applies the same decompression to streaming responses before handing off to the stream reader.
- Changelog entry under `generators/go/sdk/changes/unreleased/`.
- [ ] Updated README.md generator (not applicable)

Part of a series of per-language gzip fixes: Go (this PR), Rust #16920, C# #16921, Ruby #16922, Java #16923.

## Testing
- [x] Unit tests added/updated — `TestCallWithGzipResponse` in `caller_test.go_` (httptest server responds with gzip body when the request sets `Accept-Encoding: gzip` explicitly)
- [x] Manual testing completed — rendered templates into the `seed/go-sdk/alias` fixture module; `go build ./...`, `go vet`, and the `./internal` test suite pass

Link to Devin session: https://app.devin.ai/sessions/90aef2978d1448fd85ad153356d5625f
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->