### PR TITLE
feat(csharp): add default-timeout-in-milliseconds config and deprecate seconds key

### DIFF
--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -249,8 +249,22 @@ export class Generation {
         maxRetries: () => this.customConfig.maxRetries,
         /** Controls which HTTP status codes trigger automatic retries. Default: "legacy". */
         retryStatusCodes: () => this.customConfig.retryStatusCodes ?? "legacy",
-        /** Override the default request timeout (in seconds) for the generated SDK client. `"infinity"` disables the default timeout. Default: 30. */
-        defaultTimeoutInSeconds: () => this.customConfig["default-timeout-in-seconds"],
+        /**
+         * Override the default request timeout (in milliseconds) for the generated SDK client. `"infinity"` disables
+         * the default timeout. Resolves the new `default-timeout-in-milliseconds` key when set, otherwise falls back
+         * to the deprecated `default-timeout-in-seconds` (converted to milliseconds). Default: 30000.
+         */
+        defaultTimeoutInMilliseconds: (): number | "infinity" | undefined => {
+            const milliseconds = this.customConfig["default-timeout-in-milliseconds"];
+            if (milliseconds != null) {
+                return milliseconds;
+            }
+            const seconds = this.customConfig["default-timeout-in-seconds"];
+            if (seconds == null) {
+                return undefined;
+            }
+            return seconds === "infinity" ? "infinity" : seconds * 1000;
+        },
         /**
          * Output path configuration for generated files.
          * Returns normalized paths for library, test, solution, and other files.

--- a/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
+++ b/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
@@ -127,7 +127,13 @@ export const CsharpConfigSchema = z.object({
         .union([z.number().positive(), z.literal("infinity")])
         .optional()
         .describe(
-            "The default timeout for network requests, in seconds. Set to `infinity` to disable the default timeout. SDK users can still override this per-request via request options."
+            "(Deprecated) The default timeout for network requests, in seconds. Use `default-timeout-in-milliseconds` instead. Set to `infinity` to disable the default timeout. SDK users can still override this per-request via request options."
+        ),
+    "default-timeout-in-milliseconds": z
+        .union([z.number().positive(), z.literal("infinity")])
+        .optional()
+        .describe(
+            "The default timeout for network requests, in milliseconds. Set to `infinity` to disable the default timeout. Takes precedence over the deprecated `default-timeout-in-seconds`. SDK users can still override this per-request via request options."
         )
 });
 

--- a/generators/csharp/codegen/src/custom-config/__test__/defaultTimeoutInSeconds.test.ts
+++ b/generators/csharp/codegen/src/custom-config/__test__/defaultTimeoutInSeconds.test.ts
@@ -1,5 +1,20 @@
+import { FernIr } from "@fern-fern/ir-sdk";
 import { describe, expect, it } from "vitest";
+import { MinimalGeneratorConfig } from "../../context/common.js";
+import { Generation } from "../../context/generation-info.js";
 import { CsharpConfigSchema } from "../CsharpConfigSchema.js";
+
+type IntermediateRepresentation = FernIr.IntermediateRepresentation;
+
+function resolveTimeoutInMilliseconds(customConfig: CsharpConfigSchema): number | "infinity" | undefined {
+    const generation = new Generation(
+        {} as unknown as IntermediateRepresentation,
+        "",
+        customConfig,
+        {} as MinimalGeneratorConfig
+    );
+    return generation.settings.defaultTimeoutInMilliseconds;
+}
 
 describe("C# default-timeout-in-seconds config", () => {
     it("should accept a positive number", () => {
@@ -47,5 +62,70 @@ describe("C# default-timeout-in-seconds config", () => {
     it("should reject other strings", () => {
         const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": "60" });
         expect(result.success).toBe(false);
+    });
+});
+
+describe("C# default-timeout-in-milliseconds config", () => {
+    it("should accept a positive number", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-milliseconds": 500 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data["default-timeout-in-milliseconds"]).toBe(500);
+        }
+    });
+
+    it("should accept the literal 'infinity'", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-milliseconds": "infinity" });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data["default-timeout-in-milliseconds"]).toBe("infinity");
+        }
+    });
+
+    it("should reject zero", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-milliseconds": 0 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject negative numbers", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-milliseconds": -1 });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe("C# timeout resolution (milliseconds)", () => {
+    it("should be undefined when neither key is set", () => {
+        expect(resolveTimeoutInMilliseconds({})).toBeUndefined();
+    });
+
+    it("should use the milliseconds key directly when set", () => {
+        expect(resolveTimeoutInMilliseconds({ "default-timeout-in-milliseconds": 500 })).toBe(500);
+    });
+
+    it("should convert the deprecated seconds key to milliseconds", () => {
+        expect(resolveTimeoutInMilliseconds({ "default-timeout-in-seconds": 60 })).toBe(60_000);
+    });
+
+    it("should convert fractional seconds to milliseconds", () => {
+        expect(resolveTimeoutInMilliseconds({ "default-timeout-in-seconds": 1.5 })).toBe(1500);
+    });
+
+    it("should preserve 'infinity' from the deprecated seconds key", () => {
+        expect(resolveTimeoutInMilliseconds({ "default-timeout-in-seconds": "infinity" })).toBe("infinity");
+    });
+
+    it("should let the milliseconds key take precedence when both are set", () => {
+        expect(
+            resolveTimeoutInMilliseconds({
+                "default-timeout-in-milliseconds": 500,
+                "default-timeout-in-seconds": 60
+            })
+        ).toBe(500);
+    });
+
+    it("should produce equivalent output for the old and new keys", () => {
+        expect(resolveTimeoutInMilliseconds({ "default-timeout-in-seconds": 30 })).toBe(
+            resolveTimeoutInMilliseconds({ "default-timeout-in-milliseconds": 30_000 })
+        );
     });
 });

--- a/generators/csharp/sdk/changes/unreleased/feat-default-timeout-in-milliseconds.yml
+++ b/generators/csharp/sdk/changes/unreleased/feat-default-timeout-in-milliseconds.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add a `default-timeout-in-milliseconds` config option to the C# SDK generator
+    for expressing the default network timeout in milliseconds (mapping to .NET's
+    `TimeSpan`). The generated `ClientOptions.Timeout` is now computed from
+    milliseconds (or `Timeout.InfiniteTimeSpan` when set to `"infinity"`).
+    The `default-timeout-in-seconds` option is now deprecated but remains fully
+    backwards compatible: when only the seconds key is set, it is converted to
+    milliseconds. The new key takes precedence when both are set.
+  type: feat

--- a/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
+++ b/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
@@ -120,11 +120,11 @@ export class BaseOptionsGenerator extends WithGeneration {
 
     public getTimeoutField(classOrInterface: ast.Interface | ast.Class, { optional, includeInitializer }: OptionArgs) {
         const type = this.System.TimeSpan;
-        const configured = this.settings.defaultTimeoutInSeconds;
+        const configured = this.settings.defaultTimeoutInMilliseconds;
         const initializer =
             configured === "infinity"
                 ? this.csharp.codeblock("System.Threading.Timeout.InfiniteTimeSpan")
-                : this.csharp.codeblock(`TimeSpan.FromSeconds(${configured ?? 30})`);
+                : this.csharp.codeblock(`TimeSpan.FromMilliseconds(${configured ?? 30000})`);
         classOrInterface.addField({
             origin: classOrInterface.explicit("Timeout"),
             access: ast.Access.Public,

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/allof-inline/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/allof/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/allof/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/Core/Public/ClientOptions.cs
@@ -80,7 +80,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The username to use for authentication.

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     public string? Version { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Core/Public/ClientOptions.cs
@@ -79,7 +79,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     public string? Version { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/circular-references-extends/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/circular-references-extends/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/cli-multi-spec/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/cli-multi-spec/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
@@ -70,7 +70,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The options used for gRPC client endpoints.

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -65,7 +65,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The options used for gRPC client endpoints.

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/Public/ClientOptions.cs
@@ -65,7 +65,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The options used for gRPC client endpoints.

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/Public/ClientOptions.cs
@@ -65,7 +65,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The options used for gRPC client endpoints.

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -65,7 +65,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The options used for gRPC client endpoints.

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-path-param-order/no-custom-config/src/SeedCsharpPathParamOrder/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-path-param-order/no-custom-config/src/SeedCsharpPathParamOrder/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -69,7 +69,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -62,7 +62,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/Public/ClientOptions.cs
@@ -69,7 +69,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/inline-enum-type-name-override/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/inline-enum-type-name-override/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     public string? UserAgent { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     public string? Version { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     public string? Version { get;
 #if NET5_0_OR_GREATER

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multi-content-type-examples/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-content-type-examples/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/no-content-response/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/null-type/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
@@ -80,7 +80,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// The clientId to use for authentication.

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -69,7 +69,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/object/src/SeedObject/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/openapi-subtitle/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/openapi-subtitle/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -69,7 +69,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/Public/ClientOptions.cs
@@ -67,7 +67,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance

--- a/seed/csharp-sdk/x-fern-global-parameters/src/SeedApi/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/x-fern-global-parameters/src/SeedApi/Core/Public/ClientOptions.cs
@@ -64,7 +64,7 @@ public partial class ClientOptions
 #else
         set;
 #endif
-    } = TimeSpan.FromSeconds(30);
+    } = TimeSpan.FromMilliseconds(30000);
 
     /// <summary>
     /// Clones this and returns a new instance


### PR DESCRIPTION
## Description
Adds an idiomatic millisecond-based network-timeout config key to the C# SDK generator and deprecates the seconds-based one, in a fully backwards-compatible way.

The C# generator previously only accepted `default-timeout-in-seconds`. .NET's `TimeSpan` is naturally expressed in milliseconds, so this adds `default-timeout-in-milliseconds`, deprecates the seconds key (kept fully functional), and resolves the two into a single millisecond value used to compute the generated `TimeSpan`.

## Changes Made
- **`CsharpConfigSchema.ts`**: added `default-timeout-in-milliseconds` (`positive number | "infinity"`), matching the existing seconds key's type. Marked `default-timeout-in-seconds` as `(Deprecated)` in its description (still parsed/honored).
- **`generation-info.ts`**: replaced the `defaultTimeoutInSeconds` setting with a single `defaultTimeoutInMilliseconds` resolver:
  ```ts
  const ms = config["default-timeout-in-milliseconds"];
  if (ms != null) return ms;                       // new key wins
  const s = config["default-timeout-in-seconds"];
  if (s == null) return undefined;
  return s === "infinity" ? "infinity" : s * 1000; // convert, preserving infinity
  ```
- **`BaseOptionsGenerator.getTimeoutField`**: now emits `TimeSpan.FromMilliseconds(<ms> ?? 30000)` (was `TimeSpan.FromSeconds(<s> ?? 30)`); `"infinity"` still maps to `Timeout.InfiniteTimeSpan`. Default behavior is unchanged (30000 ms == 30 s).
- **Tests** (`defaultTimeoutInSeconds.test.ts`): schema tests for the new key, plus resolution tests covering conversion (`60` → `60000`, fractional seconds, `"infinity"` preserved), new-key precedence when both are set, and equivalent output for old vs. new keys.
- **Changelog**: `feat` entry under `generators/csharp/sdk/changes/unreleased/`.
- **Seed fixtures**: regenerated `ClientOptions.cs` across all `csharp-sdk` fixtures — the default `Timeout` initializer is now `TimeSpan.FromMilliseconds(30000)`. Verified against a live `seed test --generator csharp-sdk --fixture variables` run (output matched exactly).

## Testing
- [x] Unit tests added/updated — `pnpm turbo run test --filter @fern-api/csharp-codegen` passes (628 tests, incl. 18 in `defaultTimeoutInSeconds.test.ts`)
- [x] Manual testing completed — seed regeneration of the C# SDK produces the expected `TimeSpan.FromMilliseconds(30000)` default


Link to Devin session: https://app.devin.ai/sessions/f2bdd58a1f6047619666ac67310f7a42
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->