### PR TITLE
feat(typescript): add millisecond-based defaultTimeout config

### DIFF
--- a/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
+++ b/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
@@ -34,7 +34,9 @@ export const TypescriptCustomConfigSchema = z.strictObject({
     bundle: z.optional(z.boolean()),
     allowCustomFetcher: z.optional(z.boolean()),
     generateWebSocketClients: z.optional(z.boolean()),
-    defaultTimeoutInSeconds: z.optional(z.union([z.literal("infinity"), z.number()])),
+    // Default request timeout, expressed in milliseconds (idiomatic for JS/TS, e.g.
+    // `setTimeout` / `AbortSignal.timeout(ms)`). Use "infinity" to disable the timeout.
+    defaultTimeout: z.optional(z.union([z.literal("infinity"), z.number()])),
     skipResponseValidation: z.optional(z.boolean()),
     extraDependencies: z.optional(z.record(z.string())),
     extraDevDependencies: z.optional(z.record(z.string())),
@@ -102,6 +104,9 @@ export const TypescriptCustomConfigSchema = z.strictObject({
     experimentalGenerateReadWriteOnlyTypes: z.optional(z.boolean()),
 
     // deprecated
+    // @deprecated Use `defaultTimeout` (milliseconds) instead. Converted to milliseconds (× 1000).
+    defaultTimeoutInSeconds: z.optional(z.union([z.literal("infinity"), z.number()])),
+    // @deprecated Use `defaultTimeout` (milliseconds) instead. Converted to milliseconds (× 1000).
     timeoutInSeconds: z.optional(z.union([z.literal("infinity"), z.number()])),
     includeApiReference: z.optional(z.boolean()),
     // @deprecated Use generateWebSocketClients instead
@@ -124,4 +129,30 @@ export function resolveNoSerdeLayer(config: TypescriptCustomConfigSchema | undef
         return !config.serdeLayer;
     }
     return !!config?.noSerdeLayer;
+}
+
+/**
+ * Resolves the effective default request timeout in milliseconds from config.
+ *
+ * Precedence:
+ * 1. `defaultTimeout` (already in milliseconds)
+ * 2. `defaultTimeoutInSeconds` (deprecated, converted × 1000)
+ * 3. `timeoutInSeconds` (deprecated, converted × 1000)
+ *
+ * `"infinity"` is preserved as-is (disables the timeout). Returns `undefined`
+ * when no timeout is configured, so callers can fall back to their own default.
+ */
+export function resolveTimeoutInMilliseconds(
+    config: TypescriptCustomConfigSchema | undefined
+): number | "infinity" | undefined {
+    if (config?.defaultTimeout != null) {
+        return config.defaultTimeout;
+    }
+    if (config?.defaultTimeoutInSeconds != null) {
+        return config.defaultTimeoutInSeconds === "infinity" ? "infinity" : config.defaultTimeoutInSeconds * 1000;
+    }
+    if (config?.timeoutInSeconds != null) {
+        return config.timeoutInSeconds === "infinity" ? "infinity" : config.timeoutInSeconds * 1000;
+    }
+    return undefined;
 }

--- a/generators/typescript-v2/ast/src/custom-config/__test__/defaultTimeout.test.ts
+++ b/generators/typescript-v2/ast/src/custom-config/__test__/defaultTimeout.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { resolveTimeoutInMilliseconds, TypescriptCustomConfigSchema } from "../TypescriptCustomConfigSchema.js";
+
+describe("TypeScript defaultTimeout config", () => {
+    describe("schema validation", () => {
+        it("should accept a numeric defaultTimeout (milliseconds)", () => {
+            const result = TypescriptCustomConfigSchema.safeParse({ defaultTimeout: 30000 });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.defaultTimeout).toBe(30000);
+            }
+        });
+
+        it('should accept "infinity" as defaultTimeout', () => {
+            const result = TypescriptCustomConfigSchema.safeParse({ defaultTimeout: "infinity" });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.defaultTimeout).toBe("infinity");
+            }
+        });
+
+        it("should accept config without defaultTimeout (optional)", () => {
+            const result = TypescriptCustomConfigSchema.safeParse({});
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.defaultTimeout).toBeUndefined();
+            }
+        });
+
+        it("should reject a non-numeric, non-infinity defaultTimeout", () => {
+            const result = TypescriptCustomConfigSchema.safeParse({ defaultTimeout: "30s" });
+            expect(result.success).toBe(false);
+        });
+
+        it("should still accept the deprecated defaultTimeoutInSeconds", () => {
+            const result = TypescriptCustomConfigSchema.safeParse({ defaultTimeoutInSeconds: 30 });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.defaultTimeoutInSeconds).toBe(30);
+            }
+        });
+
+        it("should still accept the deprecated timeoutInSeconds", () => {
+            const result = TypescriptCustomConfigSchema.safeParse({ timeoutInSeconds: 30 });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.timeoutInSeconds).toBe(30);
+            }
+        });
+    });
+
+    describe("resolveTimeoutInMilliseconds precedence", () => {
+        it("returns undefined when no timeout is configured", () => {
+            expect(resolveTimeoutInMilliseconds({})).toBeUndefined();
+            expect(resolveTimeoutInMilliseconds(undefined)).toBeUndefined();
+        });
+
+        it("uses defaultTimeout as-is (already milliseconds)", () => {
+            expect(resolveTimeoutInMilliseconds({ defaultTimeout: 45000 })).toBe(45000);
+        });
+
+        it("converts deprecated defaultTimeoutInSeconds to milliseconds", () => {
+            expect(resolveTimeoutInMilliseconds({ defaultTimeoutInSeconds: 30 })).toBe(30000);
+        });
+
+        it("converts deprecated timeoutInSeconds to milliseconds", () => {
+            expect(resolveTimeoutInMilliseconds({ timeoutInSeconds: 15 })).toBe(15000);
+        });
+
+        it("prefers defaultTimeout over the deprecated seconds keys", () => {
+            expect(
+                resolveTimeoutInMilliseconds({
+                    defaultTimeout: 45000,
+                    defaultTimeoutInSeconds: 30,
+                    timeoutInSeconds: 15
+                })
+            ).toBe(45000);
+        });
+
+        it("prefers defaultTimeoutInSeconds over timeoutInSeconds", () => {
+            expect(
+                resolveTimeoutInMilliseconds({
+                    defaultTimeoutInSeconds: 30,
+                    timeoutInSeconds: 15
+                })
+            ).toBe(30000);
+        });
+
+        it('preserves "infinity" from defaultTimeout', () => {
+            expect(resolveTimeoutInMilliseconds({ defaultTimeout: "infinity" })).toBe("infinity");
+        });
+
+        it('preserves "infinity" from the deprecated defaultTimeoutInSeconds', () => {
+            expect(resolveTimeoutInMilliseconds({ defaultTimeoutInSeconds: "infinity" })).toBe("infinity");
+        });
+
+        it('preserves "infinity" from the deprecated timeoutInSeconds', () => {
+            expect(resolveTimeoutInMilliseconds({ timeoutInSeconds: "infinity" })).toBe("infinity");
+        });
+
+        it("treats defaultTimeout of 0 as an explicit value (not a fallback trigger)", () => {
+            expect(resolveTimeoutInMilliseconds({ defaultTimeout: 0, defaultTimeoutInSeconds: 30 })).toBe(0);
+        });
+    });
+});

--- a/generators/typescript-v2/ast/src/index.ts
+++ b/generators/typescript-v2/ast/src/index.ts
@@ -3,6 +3,7 @@ export {
     NamingConfigSchema,
     NamingObjectSchema,
     resolveNoSerdeLayer,
+    resolveTimeoutInMilliseconds,
     TypescriptCustomConfigSchema
 } from "./custom-config/TypescriptCustomConfigSchema.js";
 export * as ts from "./typescript.js";

--- a/generators/typescript/README.md
+++ b/generators/typescript/README.md
@@ -197,13 +197,27 @@ const acme = new AcmeClient({
 });
 ```
 
-#### ✨ `defaultTimeoutInSeconds`
+#### ✨ `defaultTimeout`
 
-**Type:** number
+**Type:** number | `"infinity"`
+
+**Default:** 60000
+
+The default timeout for network requests, in **milliseconds** (idiomatic for JavaScript/TypeScript,
+e.g. `setTimeout` and `AbortSignal.timeout(ms)`). Use `"infinity"` to disable the timeout. In the
+generated client, this can be overridden at the request level.
+
+#### `defaultTimeoutInSeconds`
+
+> [!WARNING]
+> Deprecated. Use [`defaultTimeout`](#-defaulttimeout) (milliseconds) instead.
+
+**Type:** number | `"infinity"`
 
 **Default:** 60
 
-The default timeout for network requests. In the generated client, this can be overridden at the request level.
+The default timeout for network requests, in seconds. When set, it is converted to milliseconds
+(× 1000). `defaultTimeout` takes precedence when both are provided.
 
 #### ✨ `skipResponseValidation`
 

--- a/generators/typescript/sdk/changes/unreleased/add-default-timeout-milliseconds-config.yml
+++ b/generators/typescript/sdk/changes/unreleased/add-default-timeout-milliseconds-config.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add a `defaultTimeout` custom config option, expressed in milliseconds, which is idiomatic for
+    JavaScript/TypeScript (`setTimeout`, `AbortSignal.timeout(ms)`). Use `"infinity"` to disable the
+    timeout. The seconds-based `defaultTimeoutInSeconds` and `timeoutInSeconds` keys are now
+    deprecated but continue to work: their values are converted to milliseconds (× 1000). Precedence
+    is `defaultTimeout` > `defaultTimeoutInSeconds` > `timeoutInSeconds`. Generated SDK output is
+    unchanged for existing configs.
+  type: feat

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -3,6 +3,7 @@ import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { getOriginalName } from "@fern-api/ir-utils";
 import { Logger } from "@fern-api/logger";
+import { resolveTimeoutInMilliseconds } from "@fern-api/typescript-ast";
 import { getNamespaceExport, resolveNaming } from "@fern-api/typescript-base";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { AbstractGeneratorCli } from "@fern-typescript/abstract-generator-cli";
@@ -55,6 +56,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             enableForwardCompatibleEnums: parsed?.enableForwardCompatibleEnums ?? false,
             requireDefaultEnvironment: parsed?.requireDefaultEnvironment ?? false,
             defaultTimeoutInSeconds: parsed?.defaultTimeoutInSeconds ?? parsed?.timeoutInSeconds,
+            defaultTimeout: resolveTimeoutInMilliseconds(parsed),
             skipResponseValidation: noSerdeLayer || (parsed?.skipResponseValidation ?? true),
             extraDependencies: parsed?.extraDependencies ?? {},
             extraDevDependencies: parsed?.extraDevDependencies ?? {},
@@ -221,7 +223,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
                 includeOtherInUnionTypes: customConfig.includeOtherInUnionTypes,
                 enableForwardCompatibleEnums: customConfig.enableForwardCompatibleEnums,
                 requireDefaultEnvironment: customConfig.requireDefaultEnvironment,
-                defaultTimeoutInSeconds: customConfig.defaultTimeoutInSeconds,
+                defaultTimeout: customConfig.defaultTimeout,
                 skipResponseValidation: customConfig.skipResponseValidation,
                 extraDevDependencies: customConfig.extraDevDependencies,
                 extraDependencies: customConfig.extraDependencies,

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -55,7 +55,6 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             includeOtherInUnionTypes: parsed?.includeOtherInUnionTypes ?? false,
             enableForwardCompatibleEnums: parsed?.enableForwardCompatibleEnums ?? false,
             requireDefaultEnvironment: parsed?.requireDefaultEnvironment ?? false,
-            defaultTimeoutInSeconds: parsed?.defaultTimeoutInSeconds ?? parsed?.timeoutInSeconds,
             defaultTimeout: resolveTimeoutInMilliseconds(parsed),
             skipResponseValidation: noSerdeLayer || (parsed?.skipResponseValidation ?? true),
             extraDependencies: parsed?.extraDependencies ?? {},

--- a/generators/typescript/sdk/cli/src/custom-config/SdkCustomConfig.ts
+++ b/generators/typescript/sdk/cli/src/custom-config/SdkCustomConfig.ts
@@ -31,8 +31,6 @@ export interface SdkCustomConfig {
     includeOtherInUnionTypes: boolean;
     enableForwardCompatibleEnums: boolean;
     requireDefaultEnvironment: boolean;
-    /** @deprecated Use {@link defaultTimeout} (milliseconds) instead. */
-    defaultTimeoutInSeconds: number | "infinity" | undefined;
     /**
      * Effective default request timeout in milliseconds. Resolved from the
      * `defaultTimeout` config key, falling back to the deprecated

--- a/generators/typescript/sdk/cli/src/custom-config/SdkCustomConfig.ts
+++ b/generators/typescript/sdk/cli/src/custom-config/SdkCustomConfig.ts
@@ -31,7 +31,15 @@ export interface SdkCustomConfig {
     includeOtherInUnionTypes: boolean;
     enableForwardCompatibleEnums: boolean;
     requireDefaultEnvironment: boolean;
+    /** @deprecated Use {@link defaultTimeout} (milliseconds) instead. */
     defaultTimeoutInSeconds: number | "infinity" | undefined;
+    /**
+     * Effective default request timeout in milliseconds. Resolved from the
+     * `defaultTimeout` config key, falling back to the deprecated
+     * `defaultTimeoutInSeconds` / `timeoutInSeconds` keys (× 1000).
+     * `"infinity"` disables the timeout; `undefined` applies the built-in default.
+     */
+    defaultTimeout: number | "infinity" | undefined;
     skipResponseValidation: boolean;
     extraDependencies: Record<string, string>;
     extraDevDependencies: Record<string, string>;

--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -68,7 +68,7 @@ export declare namespace GeneratedSdkClientClassImpl {
         allowCustomFetcher: boolean;
         generateWebSocketClients: boolean;
         requireDefaultEnvironment: boolean;
-        defaultTimeoutInSeconds: number | "infinity" | undefined;
+        defaultTimeout: number | "infinity" | undefined;
         includeContentHeadersOnFileDownloadResponse: boolean;
         includeSerdeLayer: boolean;
         retainOriginalCasing: boolean;
@@ -142,7 +142,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
         allowCustomFetcher,
         generateWebSocketClients,
         requireDefaultEnvironment,
-        defaultTimeoutInSeconds,
+        defaultTimeout,
         includeContentHeadersOnFileDownloadResponse,
         includeSerdeLayer,
         retainOriginalCasing,
@@ -257,7 +257,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                         response: getGeneratedEndpointResponse({ response }),
                         generatedSdkClientClass: this,
                         includeCredentialsOnCrossOriginRequests,
-                        defaultTimeoutInSeconds,
+                        defaultTimeout,
                         includeSerdeLayer,
                         retainOriginalCasing: this.retainOriginalCasing,
                         omitUndefined: this.omitUndefined,
@@ -276,7 +276,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                             endpoint,
                             generatedSdkClientClass: this,
                             includeCredentialsOnCrossOriginRequests,
-                            defaultTimeoutInSeconds,
+                            defaultTimeout,
                             request: getGeneratedEndpointRequest(),
                             response: getGeneratedEndpointResponse({
                                 response: FernIr.HttpResponseBody.fileDownload(fileDownload)
@@ -302,7 +302,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                             response: getGeneratedEndpointResponse({
                                 response: FernIr.HttpResponseBody.streaming(streamingResponse)
                             }),
-                            defaultTimeoutInSeconds,
+                            defaultTimeout,
                             request: getGeneratedEndpointRequest(),
                             includeSerdeLayer,
                             retainOriginalCasing: this.retainOriginalCasing,
@@ -322,7 +322,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                             response: getGeneratedEndpointResponse({
                                 response: FernIr.HttpResponseBody.streaming(streamParameter.streamResponse)
                             }),
-                            defaultTimeoutInSeconds,
+                            defaultTimeout,
                             request: getGeneratedEndpointRequest(),
                             includeSerdeLayer,
                             retainOriginalCasing: this.retainOriginalCasing,
@@ -341,7 +341,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                             endpoint,
                             generatedSdkClientClass: this,
                             includeCredentialsOnCrossOriginRequests,
-                            defaultTimeoutInSeconds,
+                            defaultTimeout,
                             request: getGeneratedEndpointRequest(),
                             response: getGeneratedEndpointResponse({
                                 response: FernIr.HttpResponseBody.bytes(bytesResponse)

--- a/generators/typescript/sdk/client-class-generator/src/SdkClientClassGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/SdkClientClassGenerator.ts
@@ -17,7 +17,7 @@ export declare namespace SdkClientClassGenerator {
         allowCustomFetcher: boolean;
         generateWebSocketClients: boolean;
         requireDefaultEnvironment: boolean;
-        defaultTimeoutInSeconds: number | "infinity" | undefined;
+        defaultTimeout: number | "infinity" | undefined;
         npmPackage: NpmPackage | undefined;
         includeContentHeadersOnFileDownloadResponse: boolean;
         includeSerdeLayer: boolean;
@@ -56,7 +56,7 @@ export class SdkClientClassGenerator {
     private readonly allowCustomFetcher: boolean;
     private readonly generateWebSocketClients: boolean;
     private readonly requireDefaultEnvironment: boolean;
-    private readonly defaultTimeoutInSeconds: number | "infinity" | undefined;
+    private readonly defaultTimeout: number | "infinity" | undefined;
     private readonly npmPackage: NpmPackage | undefined;
     private readonly includeContentHeadersOnFileDownloadResponse: boolean;
     private readonly includeSerdeLayer: boolean;
@@ -84,7 +84,7 @@ export class SdkClientClassGenerator {
         allowCustomFetcher,
         generateWebSocketClients,
         requireDefaultEnvironment,
-        defaultTimeoutInSeconds,
+        defaultTimeout,
         npmPackage,
         includeContentHeadersOnFileDownloadResponse,
         includeSerdeLayer,
@@ -111,7 +111,7 @@ export class SdkClientClassGenerator {
         this.allowCustomFetcher = allowCustomFetcher;
         this.generateWebSocketClients = generateWebSocketClients;
         this.requireDefaultEnvironment = requireDefaultEnvironment;
-        this.defaultTimeoutInSeconds = defaultTimeoutInSeconds;
+        this.defaultTimeout = defaultTimeout;
         this.npmPackage = npmPackage;
         this.includeContentHeadersOnFileDownloadResponse = includeContentHeadersOnFileDownloadResponse;
         this.includeSerdeLayer = includeSerdeLayer;
@@ -151,7 +151,7 @@ export class SdkClientClassGenerator {
             allowCustomFetcher: this.allowCustomFetcher,
             generateWebSocketClients: this.generateWebSocketClients,
             requireDefaultEnvironment: this.requireDefaultEnvironment,
-            defaultTimeoutInSeconds: this.defaultTimeoutInSeconds,
+            defaultTimeout: this.defaultTimeout,
             includeContentHeadersOnFileDownloadResponse: this.includeContentHeadersOnFileDownloadResponse,
             includeSerdeLayer: this.includeSerdeLayer,
             retainOriginalCasing: this.retainOriginalCasing,

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -205,7 +205,7 @@ function createImpl(opts?: {
     request?: GeneratedEndpointRequest;
     response?: GeneratedEndpointResponse;
     includeCredentialsOnCrossOriginRequests?: boolean;
-    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    defaultTimeout?: number | "infinity" | undefined;
     includeSerdeLayer?: boolean;
     retainOriginalCasing?: boolean;
     omitUndefined?: boolean;
@@ -220,7 +220,7 @@ function createImpl(opts?: {
         response: opts?.response ?? createMockResponse(),
         generatedSdkClientClass: opts?.generatedSdkClientClass ?? createMockClientClass(),
         includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
-        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        defaultTimeout: opts?.defaultTimeout,
         includeSerdeLayer: opts?.includeSerdeLayer ?? true,
         retainOriginalCasing: opts?.retainOriginalCasing ?? false,
         omitUndefined: opts?.omitUndefined ?? false,

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedFileDownloadEndpointImplementation.test.ts
@@ -165,7 +165,7 @@ function createImpl(opts?: {
     request?: GeneratedEndpointRequest;
     response?: GeneratedEndpointResponse;
     includeCredentialsOnCrossOriginRequests?: boolean;
-    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    defaultTimeout?: number | "infinity" | undefined;
     includeSerdeLayer?: boolean;
     retainOriginalCasing?: boolean;
     omitUndefined?: boolean;
@@ -182,7 +182,7 @@ function createImpl(opts?: {
         response: opts?.response ?? createMockResponse(),
         generatedSdkClientClass: opts?.generatedSdkClientClass ?? createMockClientClass(),
         includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
-        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        defaultTimeout: opts?.defaultTimeout,
         includeSerdeLayer: opts?.includeSerdeLayer ?? true,
         retainOriginalCasing: opts?.retainOriginalCasing ?? false,
         omitUndefined: opts?.omitUndefined ?? false,

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -110,7 +110,7 @@ function createClientClass(opts?: {
     allowCustomFetcher?: boolean;
     generateWebSocketClients?: boolean;
     requireDefaultEnvironment?: boolean;
-    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    defaultTimeout?: number | "infinity" | undefined;
     includeContentHeadersOnFileDownloadResponse?: boolean;
     includeSerdeLayer?: boolean;
     retainOriginalCasing?: boolean;
@@ -142,7 +142,7 @@ function createClientClass(opts?: {
         allowCustomFetcher: opts?.allowCustomFetcher ?? false,
         generateWebSocketClients: opts?.generateWebSocketClients ?? false,
         requireDefaultEnvironment: opts?.requireDefaultEnvironment ?? false,
-        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        defaultTimeout: opts?.defaultTimeout,
         includeContentHeadersOnFileDownloadResponse: opts?.includeContentHeadersOnFileDownloadResponse ?? false,
         includeSerdeLayer: opts?.includeSerdeLayer ?? true,
         retainOriginalCasing: opts?.retainOriginalCasing ?? false,

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -171,7 +171,7 @@ function createImpl(opts?: {
     request?: GeneratedEndpointRequest;
     response?: GeneratedEndpointResponse;
     includeCredentialsOnCrossOriginRequests?: boolean;
-    defaultTimeoutInSeconds?: number | "infinity" | undefined;
+    defaultTimeout?: number | "infinity" | undefined;
     includeSerdeLayer?: boolean;
     retainOriginalCasing?: boolean;
     omitUndefined?: boolean;
@@ -188,7 +188,7 @@ function createImpl(opts?: {
         response: opts?.response ?? createMockResponse(),
         generatedSdkClientClass: opts?.generatedSdkClientClass ?? createMockClientClass(),
         includeCredentialsOnCrossOriginRequests: opts?.includeCredentialsOnCrossOriginRequests ?? false,
-        defaultTimeoutInSeconds: opts?.defaultTimeoutInSeconds,
+        defaultTimeout: opts?.defaultTimeout,
         includeSerdeLayer: opts?.includeSerdeLayer ?? true,
         retainOriginalCasing: opts?.retainOriginalCasing ?? false,
         omitUndefined: opts?.omitUndefined ?? false,

--- a/generators/typescript/sdk/client-class-generator/src/__test__/SdkClientClassGenerator.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/SdkClientClassGenerator.test.ts
@@ -59,7 +59,7 @@ function createGenerator(opts?: Partial<SdkClientClassGenerator.Init>): SdkClien
         allowCustomFetcher: false,
         generateWebSocketClients: false,
         requireDefaultEnvironment: false,
-        defaultTimeoutInSeconds: 60,
+        defaultTimeout: 60000,
         npmPackage: undefined,
         includeContentHeadersOnFileDownloadResponse: false,
         includeSerdeLayer: true,
@@ -91,14 +91,14 @@ describe("SdkClientClassGenerator", () => {
 
         it("constructs with custom timeout infinity", () => {
             const generator = createGenerator({
-                defaultTimeoutInSeconds: "infinity"
+                defaultTimeout: "infinity"
             });
             expect(generator).toBeDefined();
         });
 
         it("constructs with custom timeout undefined", () => {
             const generator = createGenerator({
-                defaultTimeoutInSeconds: undefined
+                defaultTimeout: undefined
             });
             expect(generator).toBeDefined();
         });

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/requestOptionsParameter.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/requestOptionsParameter.test.ts.snap
@@ -4,7 +4,7 @@ exports[`requestOptionsParameter > getAbortSignalExpression > generates abort si
 
 exports[`requestOptionsParameter > getMaxRetriesExpression > generates max retries with nullish coalescing 1`] = `"requestOptions?.maxRetries ?? this._options?.maxRetries"`;
 
-exports[`requestOptionsParameter > getTimeoutExpression > generates timeout with custom default seconds 1`] = `"(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 30) * 1000"`;
+exports[`requestOptionsParameter > getTimeoutExpression > generates timeout with custom default milliseconds 1`] = `"(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 30) * 1000"`;
 
 exports[`requestOptionsParameter > getTimeoutExpression > generates timeout with default 60 seconds 1`] = `"(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000"`;
 

--- a/generators/typescript/sdk/client-class-generator/src/__test__/requestOptionsParameter.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/requestOptionsParameter.test.ts
@@ -63,7 +63,7 @@ describe("requestOptionsParameter", () => {
 
         it("generates timeout with default 60 seconds", () => {
             const result = getTimeoutExpression({
-                defaultTimeoutInSeconds: undefined,
+                defaultTimeout: undefined,
                 timeoutInSecondsReference,
                 referenceToOptions
             });
@@ -72,9 +72,9 @@ describe("requestOptionsParameter", () => {
             expect(text).toMatchSnapshot();
         });
 
-        it("generates timeout with custom default seconds", () => {
+        it("generates timeout with custom default milliseconds", () => {
             const result = getTimeoutExpression({
-                defaultTimeoutInSeconds: 30,
+                defaultTimeout: 30000,
                 timeoutInSecondsReference,
                 referenceToOptions
             });
@@ -85,7 +85,7 @@ describe("requestOptionsParameter", () => {
 
         it("generates timeout with infinity default", () => {
             const result = getTimeoutExpression({
-                defaultTimeoutInSeconds: "infinity",
+                defaultTimeout: "infinity",
                 timeoutInSecondsReference,
                 referenceToOptions
             });

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedFileDownloadEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedFileDownloadEndpointImplementation.ts
@@ -23,7 +23,7 @@ export declare namespace GeneratedFileDownloadEndpointImplementation {
         endpoint: FernIr.HttpEndpoint;
         generatedSdkClientClass: GeneratedSdkClientClassImpl;
         includeCredentialsOnCrossOriginRequests: boolean;
-        defaultTimeoutInSeconds: number | "infinity" | undefined;
+        defaultTimeout: number | "infinity" | undefined;
         request: GeneratedEndpointRequest;
         response: GeneratedEndpointResponse;
         includeSerdeLayer: boolean;
@@ -41,7 +41,7 @@ export class GeneratedFileDownloadEndpointImplementation implements GeneratedEnd
     public readonly response: GeneratedEndpointResponse;
     private readonly generatedSdkClientClass: GeneratedSdkClientClassImpl;
     private readonly includeCredentialsOnCrossOriginRequests: boolean;
-    private readonly defaultTimeoutInSeconds: number | "infinity" | undefined;
+    private readonly defaultTimeout: number | "infinity" | undefined;
     private readonly request: GeneratedEndpointRequest;
     private readonly includeSerdeLayer: boolean;
     private readonly retainOriginalCasing: boolean;
@@ -55,7 +55,7 @@ export class GeneratedFileDownloadEndpointImplementation implements GeneratedEnd
         endpoint,
         generatedSdkClientClass,
         includeCredentialsOnCrossOriginRequests,
-        defaultTimeoutInSeconds,
+        defaultTimeout,
         request,
         response,
         includeSerdeLayer,
@@ -69,7 +69,7 @@ export class GeneratedFileDownloadEndpointImplementation implements GeneratedEnd
         this.endpoint = endpoint;
         this.generatedSdkClientClass = generatedSdkClientClass;
         this.includeCredentialsOnCrossOriginRequests = includeCredentialsOnCrossOriginRequests;
-        this.defaultTimeoutInSeconds = defaultTimeoutInSeconds;
+        this.defaultTimeout = defaultTimeout;
         this.request = request;
         this.response = response;
         this.includeSerdeLayer = includeSerdeLayer;
@@ -217,7 +217,7 @@ export class GeneratedFileDownloadEndpointImplementation implements GeneratedEnd
             url: this.getReferenceToBaseUrl(context),
             method: ts.factory.createStringLiteral(this.endpoint.method),
             timeoutInSeconds: getTimeoutExpression({
-                defaultTimeoutInSeconds: this.defaultTimeoutInSeconds,
+                defaultTimeout: this.defaultTimeout,
                 timeoutInSecondsReference: this.generatedSdkClientClass.getReferenceToTimeoutInSeconds.bind(
                     this.generatedSdkClientClass
                 ),

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
@@ -26,7 +26,7 @@ export declare namespace GeneratedStreamingEndpointImplementation {
         response: GeneratedEndpointResponse;
         generatedSdkClientClass: GeneratedSdkClientClassImpl;
         includeCredentialsOnCrossOriginRequests: boolean;
-        defaultTimeoutInSeconds: number | "infinity" | undefined;
+        defaultTimeout: number | "infinity" | undefined;
         request: GeneratedEndpointRequest;
         includeSerdeLayer: boolean;
         retainOriginalCasing: boolean;
@@ -45,7 +45,7 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
     public readonly response: GeneratedEndpointResponse;
     private readonly generatedSdkClientClass: GeneratedSdkClientClassImpl;
     private readonly includeCredentialsOnCrossOriginRequests: boolean;
-    private readonly defaultTimeoutInSeconds: number | "infinity" | undefined;
+    private readonly defaultTimeout: number | "infinity" | undefined;
     private readonly request: GeneratedEndpointRequest;
     private readonly includeSerdeLayer: boolean;
     private readonly retainOriginalCasing: boolean;
@@ -59,7 +59,7 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
         generatedSdkClientClass,
         includeCredentialsOnCrossOriginRequests,
         response,
-        defaultTimeoutInSeconds,
+        defaultTimeout,
         request,
         includeSerdeLayer,
         retainOriginalCasing,
@@ -72,7 +72,7 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
         this.generatedSdkClientClass = generatedSdkClientClass;
         this.includeCredentialsOnCrossOriginRequests = includeCredentialsOnCrossOriginRequests;
         this.response = response;
-        this.defaultTimeoutInSeconds = defaultTimeoutInSeconds;
+        this.defaultTimeout = defaultTimeout;
         this.request = request;
         this.includeSerdeLayer = includeSerdeLayer;
         this.retainOriginalCasing = retainOriginalCasing;
@@ -295,7 +295,7 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
             url: this.getReferenceToBaseUrl(context),
             method: ts.factory.createStringLiteral(this.endpoint.method),
             timeoutInSeconds: getTimeoutExpression({
-                defaultTimeoutInSeconds: this.defaultTimeoutInSeconds,
+                defaultTimeout: this.defaultTimeout,
                 timeoutInSecondsReference: this.generatedSdkClientClass.getReferenceToTimeoutInSeconds.bind(
                     this.generatedSdkClientClass
                 ),

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/GeneratedDefaultEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/GeneratedDefaultEndpointImplementation.ts
@@ -22,7 +22,7 @@ export declare namespace GeneratedDefaultEndpointImplementation {
         endpoint: FernIr.HttpEndpoint;
         generatedSdkClientClass: GeneratedSdkClientClassImpl;
         includeCredentialsOnCrossOriginRequests: boolean;
-        defaultTimeoutInSeconds: number | "infinity" | undefined;
+        defaultTimeout: number | "infinity" | undefined;
         request: GeneratedEndpointRequest;
         response: GeneratedEndpointResponse;
         includeSerdeLayer: boolean;
@@ -40,7 +40,7 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
     public readonly response: GeneratedEndpointResponse;
     private readonly generatedSdkClientClass: GeneratedSdkClientClassImpl;
     private readonly includeCredentialsOnCrossOriginRequests: boolean;
-    private readonly defaultTimeoutInSeconds: number | "infinity" | undefined;
+    private readonly defaultTimeout: number | "infinity" | undefined;
     private readonly request: GeneratedEndpointRequest;
     private readonly includeSerdeLayer: boolean;
     private readonly retainOriginalCasing: boolean;
@@ -53,7 +53,7 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
         response,
         generatedSdkClientClass,
         includeCredentialsOnCrossOriginRequests,
-        defaultTimeoutInSeconds,
+        defaultTimeout,
         request,
         includeSerdeLayer,
         retainOriginalCasing,
@@ -64,7 +64,7 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
         this.endpoint = endpoint;
         this.generatedSdkClientClass = generatedSdkClientClass;
         this.includeCredentialsOnCrossOriginRequests = includeCredentialsOnCrossOriginRequests;
-        this.defaultTimeoutInSeconds = defaultTimeoutInSeconds;
+        this.defaultTimeout = defaultTimeout;
         this.request = request;
         this.response = response;
         this.includeSerdeLayer = includeSerdeLayer;
@@ -770,7 +770,7 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
         }
 
         const timeoutExpression = getTimeoutExpression({
-            defaultTimeoutInSeconds: this.defaultTimeoutInSeconds,
+            defaultTimeout: this.defaultTimeout,
             timeoutInSecondsReference: this.generatedSdkClientClass.getReferenceToTimeoutInSeconds.bind(
                 this.generatedSdkClientClass
             ),
@@ -911,7 +911,7 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
             url: urlOverride ?? this.getReferenceToBaseUrl(context),
             method: ts.factory.createStringLiteral(this.endpoint.method),
             timeoutInSeconds: getTimeoutExpression({
-                defaultTimeoutInSeconds: this.defaultTimeoutInSeconds,
+                defaultTimeout: this.defaultTimeout,
                 timeoutInSecondsReference: this.generatedSdkClientClass.getReferenceToTimeoutInSeconds.bind(
                     this.generatedSdkClientClass
                 ),

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/requestOptionsParameter.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/requestOptionsParameter.ts
@@ -18,17 +18,24 @@ export const getRequestOptionsParameter = ({
 };
 
 export const getTimeoutExpression = ({
-    defaultTimeoutInSeconds,
+    defaultTimeout,
     timeoutInSecondsReference,
     referenceToOptions
 }: {
-    defaultTimeoutInSeconds: number | "infinity" | undefined;
+    /** Effective default timeout in milliseconds (`"infinity"` disables it). */
+    defaultTimeout: number | "infinity" | undefined;
     timeoutInSecondsReference: (args: {
         referenceToRequestOptions: ts.Expression;
         isNullable: boolean;
     }) => ts.Expression;
     referenceToOptions: ts.Expression;
 }): ts.Expression => {
+    // The generated SDK's runtime timeout option is expressed in seconds and multiplied by 1000
+    // at the call site, so convert the resolved millisecond default back into seconds for the
+    // emitted literal. This keeps generated output identical to the seconds-based config.
+    const defaultTimeoutInSeconds =
+        defaultTimeout === "infinity" ? "infinity" : defaultTimeout != null ? defaultTimeout / 1000 : undefined;
+
     const requestOptionsTimeout = timeoutInSecondsReference({
         referenceToRequestOptions: ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME),
         isNullable: true

--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -126,7 +126,7 @@ export declare namespace SdkGenerator {
         includeOtherInUnionTypes: boolean;
         enableForwardCompatibleEnums: boolean;
         requireDefaultEnvironment: boolean;
-        defaultTimeoutInSeconds: number | "infinity" | undefined;
+        defaultTimeout: number | "infinity" | undefined;
         skipResponseValidation: boolean;
         extraDependencies: Record<string, string>;
         extraDevDependencies: Record<string, string>;
@@ -533,7 +533,7 @@ export class SdkGenerator {
             allowCustomFetcher: config.allowCustomFetcher,
             generateWebSocketClients: this.generateWebSocketClients,
             requireDefaultEnvironment: config.requireDefaultEnvironment,
-            defaultTimeoutInSeconds: config.defaultTimeoutInSeconds,
+            defaultTimeout: config.defaultTimeout,
             npmPackage,
             includeContentHeadersOnFileDownloadResponse: config.includeContentHeadersOnFileDownloadResponse,
             includeSerdeLayer: config.includeSerdeLayer,


### PR DESCRIPTION
## Description

The TypeScript SDK generators express the default request timeout in **seconds** (`defaultTimeoutInSeconds` / the older `timeoutInSeconds`). In JS/TS, milliseconds are idiomatic (`setTimeout`, `AbortSignal.timeout(ms)`). This PR adds a new milliseconds-based `defaultTimeout` config key, deprecates the seconds-based keys, and converts deprecated values into the new one — fully backwards-compatibly. Generated SDK output is unchanged for existing configs.

## Changes Made

**Shared schema + resolver** (`generators/typescript-v2/ast`, used by both v1 and v2):
- Added `defaultTimeout: z.optional(z.union([z.literal("infinity"), z.number()]))` (milliseconds) to `TypescriptCustomConfigSchema`.
- Moved `defaultTimeoutInSeconds` into the deprecated section (alongside the already-deprecated `timeoutInSeconds`) with `@deprecated` comments.
- Added and exported `resolveTimeoutInMilliseconds(config)` which returns the effective timeout in ms with precedence `defaultTimeout` > `defaultTimeoutInSeconds` (×1000) > `timeoutInSeconds` (×1000), preserving `"infinity"` and returning `undefined` when nothing is set:

  ```ts
  if (config?.defaultTimeout != null) return config.defaultTimeout;                 // already ms
  if (config?.defaultTimeoutInSeconds != null) return sec === "infinity" ? "infinity" : sec * 1000;
  if (config?.timeoutInSeconds != null) return sec === "infinity" ? "infinity" : sec * 1000;
  return undefined;
  ```

**v1 SDK generator** (`generators/typescript/sdk`):
- `SdkGeneratorCli` resolves a single `defaultTimeout` (ms) via `resolveTimeoutInMilliseconds(parsed)` and threads it through `SdkGenerator` → `SdkClientClassGenerator` → `GeneratedSdkClientClassImpl` → endpoint implementations. The old per-field plumbing (`defaultTimeoutInSeconds`) is dropped from the internal `SdkCustomConfig` since the resolved ms value now carries all three keys.
- `getTimeoutExpression` now receives milliseconds and converts back to seconds for the emitted literal, since the generated SDK's runtime `timeoutInSeconds` option is multiplied by 1000 at the call site. This keeps generated output byte-identical to the seconds-based config, and round-trips correctly for sub-second values (e.g. `defaultTimeout: 1500` → emitted `1.5` → `* 1000` = 1500ms):

  ```ts
  const defaultTimeoutInSeconds =
      defaultTimeout === "infinity" ? "infinity" : defaultTimeout != null ? defaultTimeout / 1000 : undefined;
  ```

**v2**: the only consumer of these keys that emits a timeout into generated SDK code is the v1 generator (which shares this schema); the typescript-v2 dynamic-snippets path does not emit a default timeout, so no v2 emission site needed changing.

- [x] Updated README.md generator (documented `defaultTimeout` and deprecated `defaultTimeoutInSeconds`)

## Testing

- [x] Unit tests added/updated
  - New `defaultTimeout.test.ts` in the ast package: schema validation (accepts ms / `"infinity"` / optional, rejects bad values, still accepts deprecated keys) + `resolveTimeoutInMilliseconds` precedence, conversion, `"infinity"` preservation, and `defaultTimeout: 0` treated as explicit.
  - Updated `client-class-generator` unit tests to pass milliseconds; the `getTimeoutExpression` snapshot for `defaultTimeout: 30000` is byte-identical to the old `defaultTimeoutInSeconds: 30` (`(requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 30) * 1000`).
  - `client-class-generator` suite: 552 passed. ast suite: 48 passed.
- [x] Manual testing completed
  - `pnpm turbo run compile` across all 40 dependent packages passes.
  - Regenerated seed fixtures locally (`exhaustive`, `streaming`, `file-download`, `bytes-download` — 30/30 cases passed) with **zero diff** vs committed output, confirming existing configs produce equivalent generated code.

Link to Devin session: https://app.devin.ai/sessions/5b316d38fd1d4c32a85b4c23fa6779e6
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->