### PR TITLE
fix(cli): prevent --version AUTO from leaking literal "AUTO" into self-hosted SDK publish config

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-selfhosted-auto-version-publish-config.yml
+++ b/packages/cli/cli/changes/unreleased/fix-selfhosted-auto-version-publish-config.yml
@@ -2,8 +2,9 @@
 
 - summary: |
     Fix `--version AUTO` leaking the literal "AUTO" string into self-hosted generated
-    SDKs. The IR publishing config now uses the language-mapped magic version placeholder
-    ("0.0.0-fern-placeholder") instead of the raw "AUTO" version, so package.json,
-    version.ts, the User-Agent header, and X-Fern-SDK-Version are stamped with the
-    computed version after post-generation replacement rather than "AUTO".
+    SDKs. Both the IR version field (which drives the User-Agent header and
+    X-Fern-SDK-Version) and the IR publishing config (which drives package.json and
+    version.ts) now use the language-mapped magic version placeholder
+    ("0.0.0-fern-placeholder") instead of the raw "AUTO" version, so these fields are
+    stamped with the computed version after post-generation replacement rather than "AUTO".
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-selfhosted-auto-version-publish-config.yml
+++ b/packages/cli/cli/changes/unreleased/fix-selfhosted-auto-version-publish-config.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `--version AUTO` leaking the literal "AUTO" string into self-hosted generated
+    SDKs. The IR publishing config now uses the language-mapped magic version placeholder
+    ("0.0.0-fern-placeholder") instead of the raw "AUTO" version, so package.json,
+    version.ts, the User-Agent header, and X-Fern-SDK-Version are stamped with the
+    computed version after post-generation replacement rather than "AUTO".
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/getPublishConfig.autoVersion.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/getPublishConfig.autoVersion.test.ts
@@ -1,0 +1,102 @@
+import { generatorsYml } from "@fern-api/configuration";
+import { MAGIC_VERSION, MAGIC_VERSION_PYTHON } from "@fern-api/generator-cli/autoversion";
+import { TaskContext } from "@fern-api/task-context";
+import { describe, expect, it } from "vitest";
+import { getPublishConfig } from "../runLocalGenerationForWorkspace.js";
+
+// Minimal TaskContext stub — getPublishConfig only reads `logger.debug`/`logger.warn`.
+const mockContext = {
+    logger: {
+        debug: () => undefined,
+        warn: () => undefined
+    }
+    // Test mock: getPublishConfig only touches the logger.
+} as unknown as TaskContext;
+
+function buildGeneratorInvocation(fields: {
+    name: string;
+    language: string;
+    github: { uri: string; token: string; mode: string };
+    output: { location: string; "package-name": string };
+}): generatorsYml.GeneratorInvocation {
+    // Test mock: only the fields read by getPublishConfig are populated.
+    return {
+        name: fields.name,
+        language: fields.language,
+        outputMode: { type: "github" },
+        raw: {
+            github: fields.github,
+            output: fields.output
+        }
+    } as unknown as generatorsYml.GeneratorInvocation;
+}
+
+describe("getPublishConfig — --version AUTO does not leak the literal 'AUTO' string", () => {
+    it("substitutes the magic placeholder into the self-hosted GitHub npm publish target", () => {
+        const publishConfig = getPublishConfig({
+            generatorInvocation: buildGeneratorInvocation({
+                name: "fernapi/fern-typescript-sdk",
+                language: "typescript",
+                github: { uri: "acme/acme-js", token: "${GITHUB_TOKEN}", mode: "pull-request" },
+                output: { location: "npm", "package-name": "@acme/sdk" }
+            }),
+            version: "AUTO",
+            userProvidedVersion: "AUTO",
+            packageName: "@acme/sdk",
+            context: mockContext
+        });
+
+        expect(publishConfig?.type).toBe("github");
+        if (publishConfig?.type === "github") {
+            expect(publishConfig.target?.type).toBe("npm");
+            if (publishConfig.target?.type === "npm") {
+                expect(publishConfig.target.version).toBe(MAGIC_VERSION);
+                expect(publishConfig.target.version).not.toBe("AUTO");
+            }
+        }
+    });
+
+    it("uses the Python-flavored magic placeholder for a self-hosted pypi target", () => {
+        const publishConfig = getPublishConfig({
+            generatorInvocation: buildGeneratorInvocation({
+                name: "fernapi/fern-python-sdk",
+                language: "python",
+                github: { uri: "acme/acme-py", token: "${GITHUB_TOKEN}", mode: "pull-request" },
+                output: { location: "pypi", "package-name": "acme-sdk" }
+            }),
+            version: "AUTO",
+            userProvidedVersion: "AUTO",
+            packageName: "acme-sdk",
+            context: mockContext
+        });
+
+        expect(publishConfig?.type).toBe("github");
+        if (publishConfig?.type === "github") {
+            expect(publishConfig.target?.type).toBe("pypi");
+            if (publishConfig.target?.type === "pypi") {
+                expect(publishConfig.target.version).toBe(MAGIC_VERSION_PYTHON);
+                expect(publishConfig.target.version).not.toBe("AUTO");
+            }
+        }
+    });
+
+    it("preserves an explicit version unchanged", () => {
+        const publishConfig = getPublishConfig({
+            generatorInvocation: buildGeneratorInvocation({
+                name: "fernapi/fern-typescript-sdk",
+                language: "typescript",
+                github: { uri: "acme/acme-js", token: "${GITHUB_TOKEN}", mode: "pull-request" },
+                output: { location: "npm", "package-name": "@acme/sdk" }
+            }),
+            version: "1.2.3",
+            userProvidedVersion: "1.2.3",
+            packageName: "@acme/sdk",
+            context: mockContext
+        });
+
+        expect(publishConfig?.type).toBe("github");
+        if (publishConfig?.type === "github" && publishConfig.target?.type === "npm") {
+            expect(publishConfig.target.version).toBe("1.2.3");
+        }
+    });
+});

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -15,7 +15,13 @@ import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { createVenusService } from "@fern-api/core";
 import { ContainerRunner, extractErrorMessage, replaceEnvVariables } from "@fern-api/core-utils";
 import { AbsoluteFilePath, dirname, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { AutoVersioningCache, isAutoVersion } from "@fern-api/generator-cli/autoversion";
+import {
+    AutoVersioningCache,
+    extractLanguageFromGeneratorName,
+    isAutoVersion,
+    MAGIC_VERSION,
+    mapMagicVersionForLanguage
+} from "@fern-api/generator-cli/autoversion";
 import {
     buildReplayTelemetryProps,
     logReplaySummary,
@@ -587,7 +593,7 @@ export async function getWorkspaceTempDir(): Promise<tmp.DirectoryResult> {
     });
 }
 
-function getPublishConfig({
+export function getPublishConfig({
     generatorInvocation,
     org,
     version,
@@ -604,6 +610,19 @@ function getPublishConfig({
     context: TaskContext;
     generateTests?: boolean;
 }): FernIr.PublishingConfig | undefined {
+    // When version is AUTO, substitute the language-mapped magic placeholder
+    // ("0.0.0-fern-placeholder") so the version stamped into the generated SDK's
+    // publish target (and therefore package.json, version.ts, the User-Agent header,
+    // and X-Fern-SDK-Version) is a safe placeholder that the post-generation step can
+    // cleanly replace — instead of the literal "AUTO" string.
+    const publishLanguage = generatorInvocation.language ?? extractLanguageFromGeneratorName(generatorInvocation.name);
+    const substituteAutoVersion = (candidate: string | undefined): string | undefined =>
+        candidate != null && isAutoVersion(candidate)
+            ? mapMagicVersionForLanguage(MAGIC_VERSION, publishLanguage)
+            : candidate;
+    const effectiveVersion = substituteAutoVersion(version);
+    const effectiveUserProvidedVersion = substituteAutoVersion(userProvidedVersion);
+
     if (generatorInvocation.raw?.github != null && isGithubSelfhosted(generatorInvocation.raw.github)) {
         const parsed = parseRepository(generatorInvocation.raw.github.uri);
 
@@ -616,7 +635,11 @@ function getPublishConfig({
             token: generatorInvocation.raw.github.token,
             mode: irMode,
             branch: generatorInvocation.raw.github.branch,
-            target: getPublishTarget({ outputSchema: generatorInvocation.raw.output, version, packageName })
+            target: getPublishTarget({
+                outputSchema: generatorInvocation.raw.output,
+                version: effectiveVersion,
+                packageName
+            })
         });
     }
 
@@ -624,38 +647,40 @@ function getPublishConfig({
         let publishTarget: PublishTarget | undefined = undefined;
         if (generatorInvocation.language === "python") {
             publishTarget = PublishTarget.pypi({
-                version,
+                version: effectiveVersion,
                 packageName
             });
-            context.logger.debug(`Created PyPiPublishTarget: version ${version} package name: ${packageName}`);
+            context.logger.debug(`Created PyPiPublishTarget: version ${effectiveVersion} package name: ${packageName}`);
         } else if (generatorInvocation.language === "typescript") {
             // Only populate the npm publish target when the user explicitly passed
             // `--version`. We intentionally do NOT thread auto-computed versions or
             // package names on their own — doing so would cause unrelated behavior
             // changes (e.g. auto-bumping a version from the npm registry) for users
             // who rely on managing `package.json` themselves.
-            if (userProvidedVersion != null) {
+            if (effectiveUserProvidedVersion != null) {
                 const tsPackageName =
                     packageName ??
                     (typeof generatorInvocation.raw?.config === "object" && generatorInvocation.raw?.config !== null
                         ? (generatorInvocation.raw.config as { packageJson?: { name?: string } }).packageJson?.name
                         : undefined);
                 publishTarget = PublishTarget.npm({
-                    version: userProvidedVersion,
+                    version: effectiveUserProvidedVersion,
                     packageName: tsPackageName,
                     tokenEnvironmentVariable: ""
                 });
                 context.logger.debug(
-                    `Created NpmPublishTarget: version ${userProvidedVersion} package name: ${tsPackageName}`
+                    `Created NpmPublishTarget: version ${effectiveUserProvidedVersion} package name: ${tsPackageName}`
                 );
             }
         } else if (generatorInvocation.language === "rust") {
             // Use Crates publish target for Rust (Cargo/crates.io)
             publishTarget = PublishTarget.crates({
-                version,
+                version: effectiveVersion,
                 packageName
             });
-            context.logger.debug(`Created CratesPublishTarget: version ${version} package name: ${packageName}`);
+            context.logger.debug(
+                `Created CratesPublishTarget: version ${effectiveVersion} package name: ${packageName}`
+            );
         } else if (generatorInvocation.language === "go") {
             // Only populate the go publish target when the user explicitly passed
             // `--version`. We intentionally do NOT thread auto-computed versions
@@ -663,7 +688,7 @@ function getPublishConfig({
             // (module versions are set via git tags), so the only reason to
             // populate this is when the user asked us to stamp the SDK with a
             // specific version (e.g. for the `X-Fern-SDK-Version` header).
-            if (userProvidedVersion != null) {
+            if (effectiveUserProvidedVersion != null) {
                 const goModulePath = (() => {
                     const config = generatorInvocation.raw?.config;
                     if (typeof config !== "object" || config === null) {
@@ -676,11 +701,11 @@ function getPublishConfig({
                     return module.path;
                 })();
                 publishTarget = PublishTarget.go({
-                    version: userProvidedVersion,
+                    version: effectiveUserProvidedVersion,
                     modulePath: goModulePath
                 });
                 context.logger.debug(
-                    `Created GoPublishTarget: version ${userProvidedVersion} module path: ${goModulePath}`
+                    `Created GoPublishTarget: version ${effectiveUserProvidedVersion} module path: ${goModulePath}`
                 );
             }
         } else if (generatorInvocation.language === "java") {
@@ -721,7 +746,7 @@ function getPublishConfig({
             const coordinate = mavenCoordinate ? `${mavenCoordinate.groupId}:${mavenCoordinate.artifactId}` : undefined;
 
             if (coordinate) {
-                const mavenVersion = version ?? "0.0.0";
+                const mavenVersion = effectiveVersion ?? "0.0.0";
                 publishTarget = PublishTarget.maven({
                     coordinate,
                     version: mavenVersion,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -169,6 +169,17 @@ export async function runLocalGenerationForWorkspace({
                 const userAgentTemplate = getUserAgentTemplateFromGeneratorConfig(generatorInvocation);
                 version = version ?? (await computeSemanticVersion({ packageName, generatorInvocation }));
 
+                // When version is AUTO, stamp the language-mapped magic placeholder into the IR
+                // instead of the literal "AUTO". The IR version drives the User-Agent header and
+                // X-Fern-SDK-Version; the post-generation step replaces the placeholder with the
+                // real computed version, whereas a literal "AUTO" would ship unreplaced.
+                const irLanguage =
+                    generatorInvocation.language ?? extractLanguageFromGeneratorName(generatorInvocation.name);
+                const effectiveIrVersion =
+                    version != null && isAutoVersion(version)
+                        ? mapMagicVersionForLanguage(MAGIC_VERSION, irLanguage)
+                        : version;
+
                 const intermediateRepresentation = generateIntermediateRepresentation({
                     workspace: fernWorkspace,
                     audiences: generatorGroup.audiences,
@@ -180,7 +191,7 @@ export async function runLocalGenerationForWorkspace({
                         disabled: generatorInvocation.disableExamples
                     },
                     readme: generatorInvocation.readme,
-                    version: version ?? (await computeSemanticVersion({ packageName, generatorInvocation })),
+                    version: effectiveIrVersion,
                     packageName,
                     userAgentTemplate,
                     organization: projectConfig.organization,


### PR DESCRIPTION
## Description

Follow-up to #16675 / #16727. Customers self-hosting SDK generation with `fern generate --version AUTO` still saw the literal string `"AUTO"` in `package.json`, `version.ts`, the `User-Agent` header, and `X-Fern-SDK-Version` on CLI 5.65.7 — even though `.fern/metadata.json` correctly showed the computed version (e.g. `4.19.0`).

### Root cause

The self-hosted local path (`runLocalGenerationForWorkspace.ts`) threads the version into the generator through **two** IR fields, and neither was magic-substituted for `AUTO`:

1. **`ir.version`** (the IR's own version field) — drives the `User-Agent` header and `X-Fern-SDK-Version` (see `generateIntermediateRepresentation.ts:578-591`). The IR is generated in-line here and passed as the `ir` param to `writeFilesToDiskAndRunGenerator`, so the `effectiveIrVersion` substitution in `runGenerator.ts:144` never applies to it.
2. **`ir.publishConfig.target.version`** — built by `getPublishConfig()` from the **raw** version string; drives `package.json` and `version.ts` (the TS generator reads `npmPackageInfoFromPublishConfig` → `publishConfig.target.version` first for self-hosted setups).

The output-mode version (`config.output.mode.<mode>.version`) *was* already substituted (#16675), which is why `.fern/metadata.json` `sdkVersion` was correct — masking that these two other fields still carried `"AUTO"`. The post-generation step only replaces the magic placeholder, so the literal `"AUTO"` survived into the shipped SDK. This split (metadata correct, code fields `"AUTO"`) is exactly what the customer reported across all four languages.

### Fix

Substitute the language-mapped magic placeholder for `AUTO` before it's baked into either IR field:

```ts
// IR version (User-Agent, X-Fern-SDK-Version)
const irLanguage = generatorInvocation.language ?? extractLanguageFromGeneratorName(generatorInvocation.name);
const effectiveIrVersion =
    version != null && isAutoVersion(version) ? mapMagicVersionForLanguage(MAGIC_VERSION, irLanguage) : version;
// ...generateIntermediateRepresentation({ version: effectiveIrVersion, ... })

// publishConfig target (package.json, version.ts) — inside getPublishConfig()
const substituteAutoVersion = (v?: string) =>
    v != null && isAutoVersion(v) ? mapMagicVersionForLanguage(MAGIC_VERSION, publishLanguage) : v;
```

Go gets `v0.0.0-fern-placeholder`, Python `0.0.0.dev0`, everything else `0.0.0-fern-placeholder`, so the post-generation replacement swaps in the computed version. Explicit `--version 1.2.3` is untouched.

## Changes Made
- `runLocalGenerationForWorkspace.ts`:
  - `generateIntermediateRepresentation` now receives the language-mapped magic placeholder (`effectiveIrVersion`) when version is `AUTO` → fixes User-Agent + X-Fern-SDK-Version.
  - `getPublishConfig()` magic-substitutes `AUTO` before constructing every publish target (npm, pypi, maven, crates, go) → fixes package.json + version.ts; exported for testability.
- Added `getPublishConfig.autoVersion.test.ts` regression tests (npm → `0.0.0-fern-placeholder`, pypi → `0.0.0.dev0`, explicit version preserved).
- Added CLI changelog entry.

## Testing
- [x] Unit tests added/updated (3 new tests, all passing)
- [x] `pnpm turbo run compile --filter @fern-api/local-workspace-runner` passes
- [x] Biome check clean

Link to Devin session: https://app.devin.ai/sessions/d7363ebb78134b23b785a4750dd9ea06
Requested by: @dvdaruri-art
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->