### PR TITLE
fix(generator-cli): fix broken "See full changelog" link in generated PR bodies

### DIFF
--- a/packages/generator-cli/changes/unreleased/fix-changelog-link-404.yml
+++ b/packages/generator-cli/changes/unreleased/fix-changelog-link-404.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix the broken "See full changelog" link in generated PR bodies. The link pointed at
+    `blob/<sha>/changelog.md`, but that file was never committed in the self-hosted (non-replay)
+    generation path, so the link 404'd. GithubStep now guarantees `changelog.md` lands in the
+    committed tree it pushes, and only emits the link when the file is actually tracked at the
+    pushed head SHA.
+  type: fix

--- a/packages/generator-cli/src/__test__/github-step-changelog-link.test.ts
+++ b/packages/generator-cli/src/__test__/github-step-changelog-link.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { buildChangelogFileContents, resolveChangelogUrl } from "../pipeline/steps/GithubStep.js";
+
+// Regression coverage for the broken "See full changelog" link in generated PR bodies.
+// The link pointed at `blob/<sha>/changelog.md`, but the file was never committed in the
+// self-hosted (non-replay) path, so the link 404'd. The link must only be emitted when
+// changelog.md is actually tracked in the committed tree, and GithubStep reconstructs the
+// file (see buildChangelogFileContents) so it lands in the pushed commit.
+
+describe("resolveChangelogUrl", () => {
+    const base = {
+        remote: "github.com",
+        owner: "acme",
+        repo: "acme-sdk",
+        headSha: "a".repeat(40)
+    };
+
+    it("emits the link when a changelog entry exists and the file is committed", () => {
+        expect(
+            resolveChangelogUrl({
+                ...base,
+                changelogEntry: "### 2.0.0\n- something",
+                changelogCommitted: true
+            })
+        ).toBe(`https://github.com/acme/acme-sdk/blob/${"a".repeat(40)}/changelog.md`);
+    });
+
+    it("omits the link when changelog.md is NOT committed (would 404)", () => {
+        expect(
+            resolveChangelogUrl({
+                ...base,
+                changelogEntry: "### 2.0.0\n- something",
+                changelogCommitted: false
+            })
+        ).toBeUndefined();
+    });
+
+    it("omits the link when there is no changelog entry", () => {
+        expect(
+            resolveChangelogUrl({
+                ...base,
+                changelogEntry: undefined,
+                changelogCommitted: true
+            })
+        ).toBeUndefined();
+    });
+
+    it("omits the link when the changelog entry is blank", () => {
+        expect(
+            resolveChangelogUrl({
+                ...base,
+                changelogEntry: "   \n  ",
+                changelogCommitted: true
+            })
+        ).toBeUndefined();
+    });
+});
+
+describe("buildChangelogFileContents", () => {
+    it("produces a versioned changelog block that matches the prependChangelogEntry format", () => {
+        const contents = buildChangelogFileContents("- Added a new endpoint", "1.4.0");
+        expect(contents.startsWith("# Changelog\n\n")).toBe(true);
+        expect(contents).toMatch(/## \[1\.4\.0\] - \d{4}-\d{2}-\d{2}\n/);
+        expect(contents).toContain("- Added a new endpoint");
+        expect(contents.endsWith("\n\n")).toBe(true);
+    });
+
+    it("falls back to a dateless header when no version is known", () => {
+        const contents = buildChangelogFileContents("- Regenerated SDK", undefined);
+        expect(contents.startsWith("# Changelog\n\n")).toBe(true);
+        expect(contents).toMatch(/## \d{4}-\d{2}-\d{2}\n/);
+        expect(contents).not.toContain("[");
+    });
+
+    it("trims surrounding whitespace from the entry", () => {
+        const contents = buildChangelogFileContents("\n\n- Trimmed entry\n\n", "2.0.0");
+        expect(contents).toContain("- Trimmed entry\n\n");
+        expect(contents).not.toContain("\n\n\n- Trimmed entry");
+    });
+});

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -162,12 +162,22 @@ export class GithubStep extends BaseStep {
             }
         }
 
+        const createdChangelog = await this.ensureChangelogFile(resolved);
+
         if (!skipCommit) {
             await this.ensureFernignore();
 
             this.logger.debug("Committing changes...");
             await repository.commitAllChanges(resolved.commitMessage);
             this.logger.debug(`Committed changes to local copy of GitHub repository at ${this.outputDir}`);
+        } else if (createdChangelog) {
+            // Replay already produced the generation commit (skipCommit) but it did not include
+            // changelog.md. Stage and commit only the reconstructed changelog so the
+            // "See full changelog" link resolves at the pushed head SHA — without re-committing
+            // generation output (which the skipCommit invariant forbids).
+            this.logger.debug("Committing reconstructed changelog.md on top of the replay commit...");
+            await repository.add("changelog.md");
+            await repository.commit(resolved.commitMessage);
         }
 
         // When skipIfNoDiff is enabled, detect no-diff before pushing.
@@ -221,9 +231,22 @@ export class GithubStep extends BaseStep {
         }
 
         const headSha = await repository.getHeadSha();
-        const changelogUrl = resolved.changelogEntry
-            ? `https://${remote}/${owner}/${repo}/blob/${headSha}/changelog.md`
-            : undefined;
+        // Only emit the "See full changelog" link when changelog.md is actually tracked in the
+        // committed tree at the pushed head SHA — otherwise the link 404s.
+        const changelogCommitted = (await repository.listTrackedFiles()).includes("changelog.md");
+        const changelogUrl = resolveChangelogUrl({
+            changelogEntry: resolved.changelogEntry,
+            changelogCommitted,
+            remote,
+            owner,
+            repo,
+            headSha
+        });
+        if (resolved.changelogEntry && !changelogCommitted) {
+            this.logger.warn(
+                'changelog.md is not present in the committed tree; omitting the "See full changelog" link.'
+            );
+        }
         const { prTitle, prBody } = parseCommitMessageForPR(
             resolved.commitMessage,
             resolved.changelogEntry,
@@ -314,6 +337,7 @@ export class GithubStep extends BaseStep {
             await repository.checkout(this.config.branch);
         }
 
+        await this.ensureChangelogFile(resolved);
         await this.ensureFernignore();
 
         this.logger.debug("Committing changes...");
@@ -368,6 +392,7 @@ export class GithubStep extends BaseStep {
             await repository.checkout(this.config.branch);
         }
 
+        await this.ensureChangelogFile(resolved);
         await this.ensureFernignore();
 
         this.logger.debug("Committing changes...");
@@ -455,6 +480,35 @@ export class GithubStep extends BaseStep {
         } catch {
             this.logger.debug("Creating .fernignore file...");
             await writeFile(fernignorePath, "# Specify files that shouldn't be modified by Fern\n", "utf-8");
+        }
+    }
+
+    /**
+     * Guarantees `changelog.md` is present in the output directory whenever a changelog entry
+     * exists for this run, so the file lands in the committed tree that GithubStep pushes and the
+     * "See full changelog" link resolves. AutoVersionStep normally writes this file via
+     * `prependChangelogEntry`; this is a safety net for paths where that write never reached the
+     * directory GithubStep commits (e.g. non-replay self-hosted generation), which previously left
+     * the link pointing at a non-existent blob (404).
+     *
+     * Returns `true` when it created the file, `false` when the file already existed (or there is
+     * no changelog entry to write).
+     */
+    private async ensureChangelogFile(resolved: ResolvedPrFields): Promise<boolean> {
+        const entry = resolved.changelogEntry?.trim();
+        if (entry == null || entry.length === 0) {
+            return false;
+        }
+        const changelogPath = join(this.outputDir, "changelog.md");
+        try {
+            await access(changelogPath);
+            // Already written (e.g. by AutoVersionStep) — don't duplicate the entry.
+            return false;
+        } catch {
+            const version = resolved.newVersion ?? resolved.previousVersion;
+            await writeFile(changelogPath, buildChangelogFileContents(entry, version), "utf-8");
+            this.logger.debug(`Wrote changelog.md${version != null ? ` for ${version}` : ""}.`);
+            return true;
         }
     }
 
@@ -638,4 +692,42 @@ export function resolveBranchAction({
         return "checkout-remote";
     }
     return "create-from-head";
+}
+
+/**
+ * Builds the contents of a fresh `changelog.md` from a changelog entry, mirroring the format
+ * produced by AutoVersionStep's `prependChangelogEntry`. Used as a safety net so the file always
+ * exists in the committed tree that GithubStep pushes.
+ */
+export function buildChangelogFileContents(entry: string, version: string | undefined): string {
+    const trimmed = entry.trim();
+    const now = new Date().toISOString().slice(0, 10);
+    const header = version != null ? `## [${version}] - ${now}\n` : `## ${now}\n`;
+    return `# Changelog\n\n${header}${trimmed}\n\n`;
+}
+
+/**
+ * Resolves the "See full changelog" link. Returns `undefined` (so the link is omitted) unless
+ * there is a changelog entry AND `changelog.md` is actually tracked in the committed tree at the
+ * pushed head SHA — otherwise the link would 404.
+ */
+export function resolveChangelogUrl({
+    changelogEntry,
+    changelogCommitted,
+    remote,
+    owner,
+    repo,
+    headSha
+}: {
+    changelogEntry: string | undefined;
+    changelogCommitted: boolean;
+    remote: string;
+    owner: string;
+    repo: string;
+    headSha: string;
+}): string | undefined {
+    if (changelogEntry == null || changelogEntry.trim().length === 0 || !changelogCommitted) {
+        return undefined;
+    }
+    return `https://${remote}/${owner}/${repo}/blob/${headSha}/changelog.md`;
 }


### PR DESCRIPTION
## Description

The "See full changelog" link in auto-generated SDK PR bodies 404s. The link points at `blob/<headSha>/changelog.md`, but in the self-hosted (non-replay) generation path `changelog.md` is never present in the committed tree at that SHA, so the blob doesn't exist.

Root cause: `AutoVersionStep.prependChangelogEntry()` writes `changelog.md` to disk, and the PR body embeds the link whenever `resolved.changelogEntry` is set — but nothing guarantees the file actually lands in the commit that `GithubStep` pushes. The link was emitted unconditionally on the *entry* existing, not on the *file* being committed.

This makes `GithubStep` the authority for both invariants:
1. Guarantee `changelog.md` is in the committed tree it pushes (reconstruct it if missing).
2. Only emit the link when the file is actually tracked at the pushed head SHA.

## Changes Made
- `GithubStep.ensureChangelogFile()`: when a changelog entry exists but `changelog.md` is missing from the output dir, reconstruct it (mirroring `prependChangelogEntry`'s format) before committing. Called in all three modes (pull-request, push, commit-and-release). For the `skipCommit` (replay) path — where re-committing generation output is forbidden — it stages and commits only the reconstructed changelog.
- `resolveChangelogUrl()` (new exported pure helper): emits the link only when there's a changelog entry AND `changelog.md` is tracked in `HEAD` (via `repository.listTrackedFiles()`); otherwise the link is omitted and a warning is logged.
- `buildChangelogFileContents()` (new exported pure helper): builds the `# Changelog` block, matching `prependChangelogEntry`.

```
before:  changelogUrl = resolved.changelogEntry ? blob/<sha>/changelog.md : undefined   // 404 when file absent
after:   ensureChangelogFile(resolved)  // file lands in committed tree
         changelogUrl = resolveChangelogUrl({ changelogEntry, changelogCommitted: HEAD tracks changelog.md, ... })
```

## Testing
- [x] Unit tests added (`github-step-changelog-link.test.ts`, 7 tests): link emitted only when committed; omitted when not committed / no entry / blank entry; changelog contents format (versioned header, dateless fallback, entry trimming).
- [x] `pnpm turbo run compile --filter @fern-api/generator-cli` passes.

This is one of three PRs addressing customer feedback on `--version AUTO` self-hosted generation (the others: literal "AUTO" leaking into publish config, and the Go module `/vN` breaking-change misclassification).

Link to Devin session: https://app.devin.ai/sessions/d7363ebb78134b23b785a4750dd9ea06
Requested by: @dvdaruri-art
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->