### PR TITLE
fix(generator-cli): stop Go SDK being flagged breaking on no-op --version AUTO regen

### DIFF
--- a/packages/generator-cli/changes/unreleased/fix-go-suffix-spurious-breaking-change.yml
+++ b/packages/generator-cli/changes/unreleased/fix-go-suffix-spurious-breaking-change.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Fix Go SDKs being flagged as a breaking change (spurious major version bump) on no-op
+    regenerations under `--version AUTO`. The freshly generated code carries the magic placeholder
+    version (major 0, no `/vN` module-path suffix) while the previously published SDK has `/vN` on
+    its module directive and every import. Because git groups all deletions before all additions in
+    an import block, the diff cleaner only stripped the first import's suffix churn and leaked the
+    rest to the AI diff analyzer, which misclassified the regeneration as breaking. The cleaner now
+    removes all Go module-path `/vN` suffix-only churn regardless of diff layout.
+  type: fix

--- a/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
+++ b/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
@@ -318,9 +318,9 @@ describe("AutoVersioningService", () => {
 
         // No suffix churn should survive — the whole file section collapses to nothing.
         expect(cleaned).not.toContain("/v4/");
-        expect(cleaned).not.toContain("core \"github.com/anduril/lattice-sdk-go/core\"");
-        expect(cleaned).not.toContain("internal \"github.com/anduril/lattice-sdk-go/internal\"");
-        expect(cleaned).not.toContain("option \"github.com/anduril/lattice-sdk-go/option\"");
+        expect(cleaned).not.toContain('core "github.com/anduril/lattice-sdk-go/core"');
+        expect(cleaned).not.toContain('internal "github.com/anduril/lattice-sdk-go/internal"');
+        expect(cleaned).not.toContain('option "github.com/anduril/lattice-sdk-go/option"');
         expect(cleaned).not.toContain("client.go");
     });
 
@@ -372,8 +372,8 @@ describe("AutoVersioningService", () => {
 
         // Suffix-only churn is gone...
         expect(cleaned).not.toContain("/v4/");
-        expect(cleaned).not.toContain("core \"github.com/anduril/lattice-sdk-go/core\"");
-        expect(cleaned).not.toContain("internal \"github.com/anduril/lattice-sdk-go/internal\"");
+        expect(cleaned).not.toContain('core "github.com/anduril/lattice-sdk-go/core"');
+        expect(cleaned).not.toContain('internal "github.com/anduril/lattice-sdk-go/internal"');
         // ...but the genuinely new import (no matching suffix-bearing deletion) survives.
         expect(cleaned).toContain('+\tnewpkg "github.com/anduril/lattice-sdk-go/newpkg"');
     });

--- a/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
+++ b/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
@@ -287,6 +287,97 @@ describe("AutoVersioningService", () => {
         expect(cleaned).not.toContain("version.go");
     });
 
+    // Regression coverage for the Go SDK being flagged as a breaking change on a no-op
+    // regeneration. The freshly generated Go code carries the magic placeholder version (major 0,
+    // so no /vN suffix), while the previously published SDK has /vN on its module path and every
+    // import. git groups all deletions before all additions in an import block, so the old
+    // near-neighbour pairing only stripped the FIRST import's suffix churn and leaked the rest to
+    // the AI analyzer, which then misclassified the diff as breaking. The whole block must be
+    // stripped so nothing reaches the analyzer.
+    it("testCleanDiffForAI_stripsGoModulePathSuffixChangesInGroupedImportBlock", () => {
+        const diff =
+            "diff --git a/client/client.go b/client/client.go\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/client/client.go\n" +
+            "+++ b/client/client.go\n" +
+            "@@ -1,9 +1,9 @@\n" +
+            " package client\n" +
+            " import (\n" +
+            '-\tcore "github.com/anduril/lattice-sdk-go/v4/core"\n' +
+            '-\tinternal "github.com/anduril/lattice-sdk-go/v4/internal"\n' +
+            '-\toption "github.com/anduril/lattice-sdk-go/v4/option"\n' +
+            '+\tcore "github.com/anduril/lattice-sdk-go/core"\n' +
+            '+\tinternal "github.com/anduril/lattice-sdk-go/internal"\n' +
+            '+\toption "github.com/anduril/lattice-sdk-go/option"\n' +
+            " )\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(
+            diff,
+            "v0.0.0-fern-placeholder"
+        );
+
+        // No suffix churn should survive — the whole file section collapses to nothing.
+        expect(cleaned).not.toContain("/v4/");
+        expect(cleaned).not.toContain("core \"github.com/anduril/lattice-sdk-go/core\"");
+        expect(cleaned).not.toContain("internal \"github.com/anduril/lattice-sdk-go/internal\"");
+        expect(cleaned).not.toContain("option \"github.com/anduril/lattice-sdk-go/option\"");
+        expect(cleaned).not.toContain("client.go");
+    });
+
+    it("testCleanDiffForAI_stripsGoModuleDirectiveSuffixButKeepsRealChanges", () => {
+        const diff =
+            "diff --git a/go.mod b/go.mod\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/go.mod\n" +
+            "+++ b/go.mod\n" +
+            "@@ -1,4 +1,4 @@\n" +
+            "-module github.com/anduril/lattice-sdk-go/v4\n" +
+            "+module github.com/anduril/lattice-sdk-go\n" +
+            " go 1.21\n" +
+            "-require github.com/pkg/errors v0.9.1\n" +
+            "+require github.com/pkg/errors v0.10.0\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(
+            diff,
+            "v0.0.0-fern-placeholder"
+        );
+
+        // The /v4 module-directive suffix churn is stripped...
+        expect(cleaned).not.toContain("module github.com/anduril/lattice-sdk-go/v4");
+        expect(cleaned).not.toContain("+module github.com/anduril/lattice-sdk-go\n");
+        // ...but a genuine dependency change on a github.com line is preserved.
+        expect(cleaned).toContain("-require github.com/pkg/errors v0.9.1");
+        expect(cleaned).toContain("+require github.com/pkg/errors v0.10.0");
+    });
+
+    it("testCleanDiffForAI_preservesGenuineGoImportAdditionAlongsideSuffixChurn", () => {
+        const diff =
+            "diff --git a/client/client.go b/client/client.go\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/client/client.go\n" +
+            "+++ b/client/client.go\n" +
+            "@@ -1,7 +1,7 @@\n" +
+            " import (\n" +
+            '-\tcore "github.com/anduril/lattice-sdk-go/v4/core"\n' +
+            '-\tinternal "github.com/anduril/lattice-sdk-go/v4/internal"\n' +
+            '+\tcore "github.com/anduril/lattice-sdk-go/core"\n' +
+            '+\tinternal "github.com/anduril/lattice-sdk-go/internal"\n' +
+            '+\tnewpkg "github.com/anduril/lattice-sdk-go/newpkg"\n' +
+            " )\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(
+            diff,
+            "v0.0.0-fern-placeholder"
+        );
+
+        // Suffix-only churn is gone...
+        expect(cleaned).not.toContain("/v4/");
+        expect(cleaned).not.toContain("core \"github.com/anduril/lattice-sdk-go/core\"");
+        expect(cleaned).not.toContain("internal \"github.com/anduril/lattice-sdk-go/internal\"");
+        // ...but the genuinely new import (no matching suffix-bearing deletion) survives.
+        expect(cleaned).toContain('+\tnewpkg "github.com/anduril/lattice-sdk-go/newpkg"');
+    });
+
     it("testExtractPreviousVersion_invalidVersionFormat_returnsUndefined", () => {
         const diff =
             "diff --git a/config.txt b/config.txt\n" +

--- a/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
+++ b/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
@@ -378,6 +378,32 @@ describe("AutoVersioningService", () => {
         expect(cleaned).toContain('+\tnewpkg "github.com/anduril/lattice-sdk-go/newpkg"');
     });
 
+    // The generated Go SDK also embeds its own module path (with the `/vN` suffix) mid-line as the
+    // `X-Fern-SDK-Name` header value, where the closing quote is followed by more characters (`)`),
+    // not end-of-line. The suffix must still be stripped there so this no-op churn does not reach
+    // the AI analyzer. Regression for a gap found during end-to-end testing against a real Go SDK.
+    it("testCleanDiffForAI_stripsGoModulePathSuffixInMidLineHeaderValue", () => {
+        const diff =
+            "diff --git a/core/request_option.go b/core/request_option.go\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/core/request_option.go\n" +
+            "+++ b/core/request_option.go\n" +
+            "@@ -52,3 +52,3 @@ func (r *RequestOptions) cloneHeader() http.Header {\n" +
+            '-\theaders.Set("X-Fern-SDK-Name", "github.com/anduril/lattice-sdk-go/v4")\n' +
+            '+\theaders.Set("X-Fern-SDK-Name", "github.com/anduril/lattice-sdk-go")\n' +
+            " \treturn headers\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(
+            diff,
+            "v0.0.0-fern-placeholder"
+        );
+
+        // Both sides of the header-value suffix churn are removed — nothing reaches the analyzer.
+        expect(cleaned).not.toContain("/v4");
+        expect(cleaned).not.toContain('"github.com/anduril/lattice-sdk-go"');
+        expect(cleaned).not.toContain("request_option.go");
+    });
+
     it("testExtractPreviousVersion_invalidVersionFormat_returnsUndefined", () => {
         const diff =
             "diff --git a/config.txt b/config.txt\n" +

--- a/packages/generator-cli/src/autoversion/AutoVersioningService.ts
+++ b/packages/generator-cli/src/autoversion/AutoVersioningService.ts
@@ -869,9 +869,11 @@ export class AutoVersioningService {
             return undefined;
         }
 
-        // Only strip /vN when it appears as a Go module version suffix
-        // (followed by / or end of quoted string or end of line)
-        const suffixPattern = /\/v\d+(?=\/|"\s*$|$)/g;
+        // Only strip /vN when it appears as a Go module version suffix: followed by a path
+        // separator (`/v4/core`), a closing quote (the module path may be embedded mid-line,
+        // e.g. the `X-Fern-SDK-Name` header value `"github.com/org/sdk/v4"`), or end of line
+        // (the bare `module` directive).
+        const suffixPattern = /\/v\d+(?=\/|"|$)/g;
         return {
             strippedContent: content.replace(suffixPattern, ""),
             hasSuffix: suffixPattern.test(content)

--- a/packages/generator-cli/src/autoversion/AutoVersioningService.ts
+++ b/packages/generator-cli/src/autoversion/AutoVersioningService.ts
@@ -864,8 +864,7 @@ export class AutoVersioningService {
 
         const goModulePathPattern = /"[^"]*(?:github\.com|golang\.org|google\.golang\.org|gopkg\.in)\/[^"]*"/;
         const goModuleDirectivePattern = /^\s*module\s+(?:github\.com|golang\.org|google\.golang\.org|gopkg\.in)\/\S+/;
-        const isGoModulePathLine =
-            goModulePathPattern.test(content) || goModuleDirectivePattern.test(content.trim());
+        const isGoModulePathLine = goModulePathPattern.test(content) || goModuleDirectivePattern.test(content.trim());
         if (!isGoModulePathLine) {
             return undefined;
         }

--- a/packages/generator-cli/src/autoversion/AutoVersioningService.ts
+++ b/packages/generator-cli/src/autoversion/AutoVersioningService.ts
@@ -614,7 +614,9 @@ export class AutoVersioningService {
             }
         }
 
-        let processedContent = this.removeVersionChangePairs(contentLines, mappedMagicVersion);
+        let processedContent = this.removeGoModulePathSuffixPairs(contentLines);
+
+        processedContent = this.removeVersionChangePairs(processedContent, mappedMagicVersion);
 
         processedContent = this.removeRemainingMagicVersionLines(processedContent, mappedMagicVersion);
 
@@ -786,33 +788,95 @@ export class AutoVersioningService {
      * so non-Go diffs like API URL version changes are not affected.
      */
     private isGoModulePathSuffixChange(minusLine: string, plusLine: string): boolean {
-        const minusContent = minusLine.substring(1);
-        const plusContent = plusLine.substring(1);
+        const minus = this.analyzeGoModulePathLine(minusLine);
+        const plus = this.analyzeGoModulePathLine(plusLine);
+        if (minus == null || plus == null) {
+            return false;
+        }
+        if (minus.strippedContent !== plus.strippedContent) {
+            return false;
+        }
+        // At least one line must actually contain a /vN suffix for this to be a suffix change
+        return minus.hasSuffix || plus.hasSuffix;
+    }
 
-        // Only apply to lines containing quoted Go module paths or go.mod module directives
+    /**
+     * Removes Go module path `/vN` suffix-only churn from a diff section, regardless of how the
+     * deletion and addition lines are laid out. `removeVersionChangePairs` only removes a deletion
+     * when it can pair it with a *nearby* addition and keeps every line in between — so a diff that
+     * groups all deletions before all additions (as Go import blocks do) leaks the suffix churn for
+     * every line except the first. That churn then reaches the AI diff analyzer, which sees the
+     * previously published `/vN` module path changing on every import and misclassifies a
+     * no-op regeneration as a breaking change (spurious major bump).
+     *
+     * This pass matches each suffix-bearing deletion with any suffix-only-equivalent addition in
+     * the section (by suffix-stripped content) and drops both, so only genuine content changes to
+     * Go module path lines survive.
+     */
+    private removeGoModulePathSuffixPairs(lines: string[]): string[] {
+        const additions: { index: number; strippedContent: string }[] = [];
+        for (let index = 0; index < lines.length; index++) {
+            const line = lines[index];
+            if (line == null || !this.isAdditionLine(line)) {
+                continue;
+            }
+            const info = this.analyzeGoModulePathLine(line);
+            if (info != null) {
+                additions.push({ index, strippedContent: info.strippedContent });
+            }
+        }
+
+        const removed = new Set<number>();
+        const usedAdditions = new Set<number>();
+        for (let index = 0; index < lines.length; index++) {
+            const line = lines[index];
+            if (line == null || !this.isDeletionLine(line)) {
+                continue;
+            }
+            const info = this.analyzeGoModulePathLine(line);
+            if (info == null || !info.hasSuffix) {
+                continue;
+            }
+            const match = additions.find(
+                (addition) => !usedAdditions.has(addition.index) && addition.strippedContent === info.strippedContent
+            );
+            if (match != null) {
+                usedAdditions.add(match.index);
+                removed.add(index);
+                removed.add(match.index);
+            }
+        }
+
+        if (removed.size === 0) {
+            return lines;
+        }
+        return lines.filter((_, index) => !removed.has(index));
+    }
+
+    /**
+     * If a diff line (with its leading +/- stripped) references a Go module path — either a quoted
+     * import path or a `module` directive — returns its content with any `/vN` module-version
+     * suffixes removed, plus whether a suffix was present. Returns undefined for non-Go lines so
+     * unrelated diffs (e.g. API URL version segments) are never touched.
+     */
+    private analyzeGoModulePathLine(line: string): { strippedContent: string; hasSuffix: boolean } | undefined {
+        const content = line.substring(1);
+
         const goModulePathPattern = /"[^"]*(?:github\.com|golang\.org|google\.golang\.org|gopkg\.in)\/[^"]*"/;
         const goModuleDirectivePattern = /^\s*module\s+(?:github\.com|golang\.org|google\.golang\.org|gopkg\.in)\/\S+/;
-        const hasGoModulePath =
-            goModulePathPattern.test(minusContent) ||
-            goModulePathPattern.test(plusContent) ||
-            goModuleDirectivePattern.test(minusContent.trim()) ||
-            goModuleDirectivePattern.test(plusContent.trim());
-        if (!hasGoModulePath) {
-            return false;
+        const isGoModulePathLine =
+            goModulePathPattern.test(content) || goModuleDirectivePattern.test(content.trim());
+        if (!isGoModulePathLine) {
+            return undefined;
         }
 
         // Only strip /vN when it appears as a Go module version suffix
         // (followed by / or end of quoted string or end of line)
         const suffixPattern = /\/v\d+(?=\/|"\s*$|$)/g;
-        const minusWithoutSuffix = minusContent.replace(suffixPattern, "");
-        const plusWithoutSuffix = plusContent.replace(suffixPattern, "");
-
-        if (minusWithoutSuffix !== plusWithoutSuffix) {
-            return false;
-        }
-
-        // At least one line must actually contain a /vN suffix for this to be a suffix change
-        return /\/v\d+(?=\/|"\s*$|$)/.test(minusContent) || /\/v\d+(?=\/|"\s*$|$)/.test(plusContent);
+        return {
+            strippedContent: content.replace(suffixPattern, ""),
+            hasSuffix: suffixPattern.test(content)
+        };
     }
 
     /**


### PR DESCRIPTION
## Description

Under `--version AUTO`, a no-op Go SDK regeneration is misclassified as a breaking change, forcing a spurious major version bump (e.g. v4 → v5).

Root cause is a diff-cleaning gap, not a real code change:
- The freshly generated Go code carries the magic placeholder version `v0.0.0-fern-placeholder` — major `0`, so it has **no** `/vN` module-path suffix. The Go `/vN` suffix is only stamped later by `addGoMajorVersionSuffix`, *after* the AI diff analysis runs.
- The previously published SDK has `/v4` on its `module` directive and on **every** import path.
- So at analysis time the diff shows `/v4` being removed from the module directive and every import.

`AutoVersioningService` already tries to filter this churn (`isGoModulePathSuffixChange`), but the filter runs inside `removeVersionChangePairs`, which only removes a deletion when it can pair it with a *near-neighbour* addition and **keeps every line in between**. git groups all deletions before all additions in an import block, so only the *first* import's suffix churn was stripped; the rest leaked to the analyzer, which then saw the module path changing across every import and called it breaking.

## Changes Made
- New `removeGoModulePathSuffixPairs()` pass in `AutoVersioningService.cleanFileSection`, run before the existing pair removal. It matches each suffix-bearing Go module-path deletion with any suffix-only-equivalent addition **anywhere in the section** (by suffix-stripped content) and drops both — layout-independent.
- Extracted `analyzeGoModulePathLine()` helper (returns suffix-stripped content + whether a `/vN` suffix was present); `isGoModulePathSuffixChange()` now reuses it. Non-Go lines return `undefined`, so unrelated diffs (e.g. API URL version segments) are untouched.
- **Mid-line suffix gap (found during end-to-end testing):** the Go SDK also embeds its own module path *mid-line* as the `X-Fern-SDK-Name` header value (`"github.com/org/sdk/v4"`), where the closing quote is followed by more characters (`)`), not end-of-line. The suffix-strip lookahead was `/\/v\d+(?=\/|"\s*$|$)/` which required whitespace-then-EOL after the quote, so it missed these. Changed to `/\/v\d+(?=\/|"|$)/` so a `/vN` suffix is stripped whenever it is followed by `/`, a closing quote, or EOL — regardless of what comes after the quote.

```
before:  -core .../v4/core                  after (block fully stripped, analyzer sees nothing):
         -internal .../v4/internal            <no change>
         -option .../v4/option
         +core .../core            <-- only this pair removed; the rest leaked as "changes"
         +internal .../internal
         +option .../option
```

## Testing
- [x] Unit tests added to `AutoVersioningService.test.ts` (4 new): grouped import block fully stripped; `module` directive suffix stripped while a genuine `require` change survives; genuinely-new import survives alongside suffix churn; **mid-line `X-Fern-SDK-Name` header-value suffix stripped** (regression for the gap found in e2e).
- [x] `AutoVersioningService.test.ts` full suite passes (128 tests); `pnpm turbo run compile --filter @fern-api/generator-cli` passes.
- [x] **End-to-end:** ran the real `AutoVersioningService.cleanDiffForAI` on a real no-op Go SDK regen diff (only `/v4` module-path churn). **Before:** 40 module-path churn lines leaked to the AI analyzer (4596-char cleaned diff) → false breaking change. **After:** 0 lines leak (empty cleaned diff) → no false breaking change.

One of three PRs addressing customer feedback on `--version AUTO` self-hosted generation (others: #16960 literal "AUTO" in publish config, #16963 broken "See full changelog" link).

Link to Devin session: https://app.devin.ai/sessions/d7363ebb78134b23b785a4750dd9ea06
Requested by: @dvdaruri-art