### PR TITLE
fix(typescript): apply exactOptionalPropertyTypes to inline request types

### DIFF
--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
@@ -128,9 +128,18 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
         };
         requestInterface.properties.push(
             ...this.getRequestProperties(context).map<PropertySignatureStructure>((property) => {
+                // When the serde layer is disabled, widen optional properties to `T | undefined`
+                // (mirroring the object type generator) so they satisfy exactOptionalPropertyTypes.
+                const typeNode =
+                    property.isOptional && !this.includeSerdeLayer
+                        ? ts.factory.createUnionTypeNode([
+                              property.type,
+                              ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword)
+                          ])
+                        : property.type;
                 return {
                     kind: StructureKind.PropertySignature,
-                    type: getTextOfTsNode(property.type),
+                    type: getTextOfTsNode(typeNode),
                     name: getPropertyKey(property.name),
                     hasQuestionToken: property.isOptional,
                     docs: property.docs

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.79.2
+  changelogEntry:
+    - summary: |
+        Apply `exactOptionalPropertyTypes` support to inline request types. With `noSerdeLayer: true`,
+        optional request properties are now generated as `propName?: Type | undefined`, matching the
+        object type generator. Previously only type declarations got the `| undefined`, so request
+        wrappers were unassignable from values that explicitly set optional fields to `undefined`.
+      type: fix
+  createdAt: "2026-07-08"
+  irVersion: 67
 - version: 3.79.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## What

With `noSerdeLayer: true`, optional properties on **inline request types** (`client/requests/*`) are now generated as `propName?: Type | undefined`, matching what the object type generator already does for type declarations.

## Why

The `exactOptionalPropertyTypes` support (added in 3.47.0) only reached the object type generator. Request wrappers still emitted plain `propName?: Type`, so under `exactOptionalPropertyTypes: true` a caller couldn't pass a value that explicitly sets an optional field to `undefined` (e.g. spreading an object where optionals are typed `T | undefined`) — even though the referenced schema type accepted it. This makes the two consistent.

## Change

One emission point in `GeneratedRequestWrapperImpl.writeToFile`: when a property is optional and the serde layer is off, widen its type node to `T | undefined` (same `!includeSerdeLayer` gate the object generator uses).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->