### PR TITLE
fix(typescript): pin npm toolchain in generated publish workflows

### DIFF
--- a/generators/cli/changes/unreleased/pin-npm-publish-toolchain.yml
+++ b/generators/cli/changes/unreleased/pin-npm-publish-toolchain.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Pin the npm toolchain used by the generated publish workflow. The
+    `publish` and `publish-launcher` jobs in `.github/workflows/ci.yml` now
+    run on a pinned Node LTS (`node-version: "lts/Krypton"`) and call
+    `npm publish` directly instead of `npx -y npm@latest publish`. Relying on
+    `npm@latest` pulled whatever npm release was newest at publish time, so a
+    broken npm release could break publishing. The pinned Node LTS bundles an
+    npm that supports OIDC trusted publishing.
+  type: fix

--- a/generators/cli/src/__test__/emitPublishWorkflow.test.ts
+++ b/generators/cli/src/__test__/emitPublishWorkflow.test.ts
@@ -49,11 +49,12 @@ describe("emitPublishWorkflow", () => {
         expect(yaml).not.toContain("id-token: write");
     });
 
-    it("uses a bare npm publish wrapper on a pinned Node toolchain (no npm@latest)", async () => {
+    it("invokes npm publish directly on a pinned Node toolchain (no wrapper, no npm@latest)", async () => {
         const yaml = await emitAndRead(baseInfo);
 
-        expect(yaml).toContain('npm publish "$@"');
+        expect(yaml).toContain("npm publish --access public");
         expect(yaml).not.toContain("npm@latest");
+        expect(yaml).not.toMatch(/publish\(\)\s*\{/);
         expect(yaml).toContain('node-version: "lts/Krypton"');
     });
 
@@ -188,12 +189,16 @@ describe("emitPublishWorkflow", () => {
         expect(yaml).not.toContain('"repository"');
     });
 
-    it("both publish steps define a publish() helper and backport logic", async () => {
+    it("both publish steps call npm publish directly with backport logic", async () => {
         const yaml = await emitAndRead(baseInfo);
 
-        // There should be two publish() helper definitions — one per publish step
-        const publishHelperMatches = yaml.match(/publish\(\)\s*\{/g);
-        expect(publishHelperMatches).toHaveLength(2);
+        // No publish() wrapper is defined anymore — npm publish is inlined.
+        expect(yaml).not.toMatch(/publish\(\)\s*\{/);
+
+        // Each step inlines four npm publish calls (alpha, beta, backport,
+        // stable) across the two publish steps.
+        const npmPublishMatches = yaml.match(/npm publish --access public/g);
+        expect(npmPublishMatches).toHaveLength(8);
 
         // Both platform and launcher steps should have backport logic
         // Each step has 2 occurrences: the echo message + the publish call

--- a/generators/cli/src/__test__/emitPublishWorkflow.test.ts
+++ b/generators/cli/src/__test__/emitPublishWorkflow.test.ts
@@ -49,11 +49,12 @@ describe("emitPublishWorkflow", () => {
         expect(yaml).not.toContain("id-token: write");
     });
 
-    it("uses npx npm@latest publish wrapper instead of bare npm publish", async () => {
+    it("uses a bare npm publish wrapper on a pinned Node toolchain (no npm@latest)", async () => {
         const yaml = await emitAndRead(baseInfo);
 
-        expect(yaml).toContain('npx -y npm@latest publish "$@"');
-        expect(yaml).not.toMatch(/^\s+npm publish/m);
+        expect(yaml).toContain('npm publish "$@"');
+        expect(yaml).not.toContain("npm@latest");
+        expect(yaml).toContain('node-version: "lts/Krypton"');
     });
 
     it("includes backport detection for stable releases", async () => {

--- a/generators/cli/src/__test__/runPipeline.test.ts
+++ b/generators/cli/src/__test__/runPipeline.test.ts
@@ -395,7 +395,7 @@ describe("runPipeline", () => {
         expect(ciYml).toContain("contains(github.ref, 'refs/tags/')");
         expect(ciYml).toContain("NPM_TOKEN");
         expect(ciYml).toContain("@acme/cli");
-        expect(ciYml).toContain("npm@latest publish");
+        expect(ciYml).toContain("npm publish");
         expect(ciYml).toContain("x86_64-unknown-linux-musl");
         expect(ciYml).toContain("aarch64-apple-darwin");
     });

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -286,26 +286,23 @@ ${matrixIncludes}
           PKGJSON
 
           cd "\${PKG_DIR}"
-          publish() {
-            npm publish "\$@"
-          }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
           # happens to contain "alpha"/"beta" as a substring isn't
           # mis-tagged on npm.
           if [[ "\${VERSION}" == *-alpha* ]]; then
-            publish --access public --tag alpha
+            npm publish --access public --tag alpha
           elif [[ "\${VERSION}" == *-beta* ]]; then
-            publish --access public --tag beta
+            npm publish --access public --tag beta
           else
             PKG_NAME=\$(node -p "require('./package.json').name")
             PKG_VERSION=\$(node -p "require('./package.json').version")
             CURRENT_LATEST=\$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
             if npx -y semver@7.8.1 "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
-              publish --access public --tag backport
+              npm publish --access public --tag backport
             else
-              publish --access public
+              npm publish --access public
             fi
           fi
 
@@ -395,26 +392,23 @@ ${launcherPlatformEntries}
           LAUNCHER
 
           cd "\${PKG_DIR}"
-          publish() {
-            npm publish "\$@"
-          }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
           # happens to contain "alpha"/"beta" as a substring isn't
           # mis-tagged on npm.
           if [[ "\${VERSION}" == *-alpha* ]]; then
-            publish --access public --tag alpha
+            npm publish --access public --tag alpha
           elif [[ "\${VERSION}" == *-beta* ]]; then
-            publish --access public --tag beta
+            npm publish --access public --tag beta
           else
             PKG_NAME=\$(node -p "require('./package.json').name")
             PKG_VERSION=\$(node -p "require('./package.json').version")
             CURRENT_LATEST=\$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
             if npx -y semver@7.8.1 "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
-              publish --access public --tag backport
+              npm publish --access public --tag backport
             else
-              publish --access public
+              npm publish --access public
             fi
           fi
 `;

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -225,6 +225,7 @@ ${matrixIncludes}
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
+          node-version: "lts/Krypton"
           registry-url: "${npmPublishInfo.registryUrl}"
 
       - name: Install musl build tools
@@ -285,8 +286,8 @@ ${matrixIncludes}
           PKGJSON
 
           cd "\${PKG_DIR}"
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "\$@"
+          publish() {
+            npm publish "\$@"
           }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
@@ -319,6 +320,7 @@ ${matrixIncludes}
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
+          node-version: "lts/Krypton"
           registry-url: "${npmPublishInfo.registryUrl}"
 
       - name: Publish launcher package${tokenEnvBlock}
@@ -393,8 +395,8 @@ ${launcherPlatformEntries}
           LAUNCHER
 
           cd "\${PKG_DIR}"
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "\$@"
+          publish() {
+            npm publish "\$@"
           }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string

--- a/generators/typescript/sdk/changes/unreleased/pin-npm-publish-toolchain.yml
+++ b/generators/typescript/sdk/changes/unreleased/pin-npm-publish-toolchain.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Pin the npm toolchain used by the generated publish workflow. The
+    `.github/workflows/ci.yml` publish job now runs on a pinned Node LTS
+    (`node-version: "lts/Krypton"`) and calls `npm publish` directly instead
+    of `npx -y npm@latest publish`. Relying on `npm@latest` pulled whatever
+    npm release was newest at publish time, so a broken npm release could
+    break publishing. The pinned Node LTS bundles an npm that supports OIDC
+    trusted publishing. The `npx semver` invocation used for backport
+    detection is also pinned to `semver@7.8.1`.
+  type: fix

--- a/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
@@ -158,22 +158,19 @@ jobs:
                 : `
           npm config set //registry.npmjs.org/:_authToken \${NPM_TOKEN}`
         }
-          publish() {
-            npm publish "$@"
-          }
           if [[ \${GITHUB_REF} == *alpha* ]]; then
-            publish --access ${access} --tag alpha
+            npm publish --access ${access} --tag alpha
           elif [[ \${GITHUB_REF} == *beta* ]]; then
-            publish --access ${access} --tag beta
+            npm publish --access ${access} --tag beta
           else
             PKG_NAME=$(node -p "require('./package.json').name")
             PKG_VERSION=$(node -p "require('./package.json').version")
             CURRENT_LATEST=$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
             if npx -y semver@7.8.1 "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
-              publish --access ${access} --tag backport
+              npm publish --access ${access} --tag backport
             else
-              publish --access ${access}
+              npm publish --access ${access}
             fi
           fi${
               useOidc

--- a/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
@@ -134,14 +134,16 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up node
-        uses: actions/setup-node@v6${
-            usePnpm
-                ? `
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"${
+              usePnpm
+                  ? `
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4`
-                : ""
-        }
+                  : ""
+          }
 
       - name: Install dependencies
         run: ${frozenInstall}
@@ -156,8 +158,8 @@ jobs:
                 : `
           npm config set //registry.npmjs.org/:_authToken \${NPM_TOKEN}`
         }
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+          publish() {
+            npm publish "$@"
           }
           if [[ \${GITHUB_REF} == *alpha* ]]; then
             publish --access ${access} --tag alpha
@@ -167,7 +169,7 @@ jobs:
             PKG_NAME=$(node -p "require('./package.json').name")
             PKG_VERSION=$(node -p "require('./package.json').version")
             CURRENT_LATEST=$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
-            if npx -y semver "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
+            if npx -y semver@7.8.1 "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
               publish --access ${access} --tag backport
             else

--- a/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
+          node-version: "lts/Krypton"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install musl build tools
@@ -144,8 +145,8 @@ jobs:
           PKGJSON
 
           cd "${PKG_DIR}"
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+          publish() {
+            npm publish "$@"
           }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
@@ -178,6 +179,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
+          node-version: "lts/Krypton"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish launcher package
@@ -258,8 +260,8 @@ jobs:
           LAUNCHER
 
           cd "${PKG_DIR}"
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+          publish() {
+            npm publish "$@"
           }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string

--- a/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
@@ -145,26 +145,23 @@ jobs:
           PKGJSON
 
           cd "${PKG_DIR}"
-          publish() {
-            npm publish "$@"
-          }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
           # happens to contain "alpha"/"beta" as a substring isn't
           # mis-tagged on npm.
           if [[ "${VERSION}" == *-alpha* ]]; then
-            publish --access public --tag alpha
+            npm publish --access public --tag alpha
           elif [[ "${VERSION}" == *-beta* ]]; then
-            publish --access public --tag beta
+            npm publish --access public --tag beta
           else
             PKG_NAME=$(node -p "require('./package.json').name")
             PKG_VERSION=$(node -p "require('./package.json').version")
             CURRENT_LATEST=$(npm view "${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
             if npx -y semver@7.8.1 "${PKG_VERSION}" -r "<${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing ${PKG_VERSION} with --tag backport (current latest is ${CURRENT_LATEST})"
-              publish --access public --tag backport
+              npm publish --access public --tag backport
             else
-              publish --access public
+              npm publish --access public
             fi
           fi
 
@@ -260,25 +257,22 @@ jobs:
           LAUNCHER
 
           cd "${PKG_DIR}"
-          publish() {
-            npm publish "$@"
-          }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
           # happens to contain "alpha"/"beta" as a substring isn't
           # mis-tagged on npm.
           if [[ "${VERSION}" == *-alpha* ]]; then
-            publish --access public --tag alpha
+            npm publish --access public --tag alpha
           elif [[ "${VERSION}" == *-beta* ]]; then
-            publish --access public --tag beta
+            npm publish --access public --tag beta
           else
             PKG_NAME=$(node -p "require('./package.json').name")
             PKG_VERSION=$(node -p "require('./package.json').version")
             CURRENT_LATEST=$(npm view "${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
             if npx -y semver@7.8.1 "${PKG_VERSION}" -r "<${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing ${PKG_VERSION} with --tag backport (current latest is ${CURRENT_LATEST})"
-              publish --access public --tag backport
+              npm publish --access public --tag backport
             else
-              publish --access public
+              npm publish --access public
             fi
           fi

--- a/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
@@ -72,21 +72,18 @@ jobs:
 
       - name: Publish to npm
         run: |
-          publish() {
-            npm publish "$@"
-          }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
-            publish --access public --tag alpha
+            npm publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then
-            publish --access public --tag beta
+            npm publish --access public --tag beta
           else
             PKG_NAME=$(node -p "require('./package.json').name")
             PKG_VERSION=$(node -p "require('./package.json').version")
             CURRENT_LATEST=$(npm view "${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
             if npx -y semver@7.8.1 "${PKG_VERSION}" -r "<${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing ${PKG_VERSION} with --tag backport (current latest is ${CURRENT_LATEST})"
-              publish --access public --tag backport
+              npm publish --access public --tag backport
             else
-              publish --access public
+              npm publish --access public
             fi
           fi

--- a/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Set up node
         uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -70,8 +72,8 @@ jobs:
 
       - name: Publish to npm
         run: |
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+          publish() {
+            npm publish "$@"
           }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
             publish --access public --tag alpha
@@ -81,7 +83,7 @@ jobs:
             PKG_NAME=$(node -p "require('./package.json').name")
             PKG_VERSION=$(node -p "require('./package.json').version")
             CURRENT_LATEST=$(npm view "${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
-            if npx -y semver "${PKG_VERSION}" -r "<${CURRENT_LATEST}" > /dev/null 2>&1; then
+            if npx -y semver@7.8.1 "${PKG_VERSION}" -r "<${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing ${PKG_VERSION} with --tag backport (current latest is ${CURRENT_LATEST})"
               publish --access public --tag backport
             else


### PR DESCRIPTION
## Description

Generated `.github/workflows/ci.yml` publish jobs (TypeScript SDK generator and CLI generator) invoked `npx -y npm@latest publish`, always pulling whatever npm release was newest at publish time. When npm shipped a broken release, generated SDKs failed to publish through no fault of the customer.

Real-world breakage this reproduces: elevenlabs-js publish failed on the broken npm release (https://github.com/elevenlabs/elevenlabs-js/actions/runs/29002660275/job/86089671090). The immediate customer-repo fix was https://github.com/elevenlabs/elevenlabs-js/pull/427; this PR applies the same fix at the source so regenerated SDKs stop pinning to a floating `npm@latest`.

`npm@latest` was used to guarantee an OIDC-capable npm (trusted publishing needs npm ≥ 11.5.1). Instead of floating npm, we pin the Node toolchain in the publish job to a Node LTS whose bundled npm supports OIDC (`node-version: "lts/Krypton"`, i.e. Node 24) and call `npm publish` directly. With the pinned toolchain the `publish()` wrapper (which only existed to shell out to `npx npm@latest`) is no longer needed, so `npm publish` is inlined at each tag branch.

```diff
      - name: Set up node
        uses: actions/setup-node@v6
+       with:
+         node-version: "lts/Krypton"
...
-         publish() {  # use latest npm to ensure OIDC support
-           npx -y npm@latest publish "$@"
-         }
-         if [[ ${GITHUB_REF} == *alpha* ]]; then
-           publish --access public --tag alpha
+         if [[ ${GITHUB_REF} == *alpha* ]]; then
+           npm publish --access public --tag alpha
          ...
```

Scope is limited to the publish job(s) — where `npm publish` actually runs and where an OIDC-capable npm is required — so the compile/test jobs (and their seed goldens) are untouched.

## Changes Made
- TS SDK generator (`writeGitHubWorkflows.ts`): pin Node in the publish job, drop the `publish()` wrapper and call `npm publish` directly (no more `npx -y npm@latest`), and pin the backport-detection `npx semver` to `semver@7.8.1`.
- CLI generator (`emitPublishWorkflow.ts`): pin Node in the `publish` and `publish-launcher` jobs and drop the wrapper in favor of direct `npm publish` (its `npx semver` was already pinned).
- Regenerated the two affected seed goldens (`ts-sdk/simple-api/oidc-token`, `cli/query-parameters-openapi/github-npm`).
- Updated CLI generator unit tests to assert the new behavior.
- Added `fix` changelog entries for the TypeScript SDK and CLI generators.

## Testing
- [x] Unit tests added/updated — `pnpm exec vitest run` on the CLI generator's `emitPublishWorkflow.test.ts` + `runPipeline.test.ts` (32 passed).
- [x] `pnpm turbo run compile` for `@fern-api/cli-generator` and `@fern-typescript/abstract-generator-cli` (green).
- [x] `biome check` on all changed source files.


Link to Devin session: https://app.devin.ai/sessions/953af0149b864526aa04225c7a4b6b01
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->