### PR TITLE
fix(cli): record changelog entries for explicit --version and never wipe changelog.md

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-explicit-version-changelog.yml
+++ b/packages/cli/cli/changes/unreleased/fix-explicit-version-changelog.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    `fern generate` with an explicit `--version X.Y.Z` now records a version-only entry
+    (version header with an empty description) in the SDK repo's `changelog.md`, and existing
+    changelog entries are preserved across regenerations instead of being wiped.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -9,6 +9,7 @@ import {
     AutoVersioningService,
     AutoVersionResult,
     CachedAnalysis,
+    changelogContainsVersion,
     countFilesInDiff,
     formatSizeKB,
     isAutoVersion,
@@ -17,13 +18,14 @@ import {
     MAX_CHUNKS,
     MAX_RAW_DIFF_BYTES,
     mapMagicVersionForLanguage,
-    maxVersionBump
+    maxVersionBump,
+    prependChangelogBlock
 } from "@fern-api/generator-cli/autoversion";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { CliError, TaskContext } from "@fern-api/task-context";
 
 import decompress from "decompress";
-import { cp, readdir, readFile, rm, stat } from "fs/promises";
+import { cp, readdir, readFile, rm, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join as pathJoin } from "path";
 import semver from "semver";
@@ -112,6 +114,7 @@ export class LocalTaskHandler {
         // Read prior changelog BEFORE copy operations overwrite the output directory
         const priorChangelog =
             this.version != null && isAutoVersion(this.version) ? await this.readPriorChangelog(3) : "";
+        const priorChangelogFile = await this.readChangelogFile();
 
         if (isFernIgnorePresent) {
             const absolutePathToFernignore = AbsoluteFilePath.of(
@@ -132,6 +135,19 @@ export class LocalTaskHandler {
             await this.copyGeneratedFilesNoFernIgnorePreservingGit();
         } else {
             await this.copyGeneratedFilesNoFernIgnoreDeleteAll();
+        }
+
+        // Generators don't emit changelog.md, so the copy operations above delete it.
+        // Restore it so changelog entries are never lost across regenerations.
+        await this.restoreChangelogFile(priorChangelogFile);
+
+        // An explicitly pinned version (e.g. `--version 0.1.0`) skips AI changelog generation,
+        // so record a version-only entry (empty description) in the changelog instead.
+        if (this.version != null && !isAutoVersion(this.version)) {
+            await this.prependExplicitVersionChangelogEntry({
+                version: this.version,
+                createIfMissing: isExistingGitRepo
+            });
         }
 
         if (
@@ -1045,6 +1061,73 @@ export class LocalTaskHandler {
             this.context.logger.debug(`Failed to read prior changelog: ${error}`);
             return "";
         }
+    }
+
+    /**
+     * Reads the full contents of the changelog file (case-insensitive `changelog.md`)
+     * in the output directory. Returns undefined when no changelog file exists.
+     */
+    private async readChangelogFile(): Promise<{ filename: string; content: string } | undefined> {
+        try {
+            const files = await readdir(this.absolutePathToLocalOutput);
+            const filename = files.find((f) => f.toLowerCase() === "changelog.md");
+            if (filename == null) {
+                return undefined;
+            }
+            const content = await readFile(
+                join(this.absolutePathToLocalOutput, RelativeFilePath.of(filename)),
+                "utf-8"
+            );
+            return { filename, content };
+        } catch (error) {
+            this.context.logger.debug(`Failed to read changelog file: ${error}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Restores the changelog file captured before the copy operations if those
+     * operations removed it (generators don't emit changelog.md, so a plain copy
+     * would silently drop all prior entries).
+     */
+    private async restoreChangelogFile(prior: { filename: string; content: string } | undefined): Promise<void> {
+        if (prior == null) {
+            return;
+        }
+        const current = await this.readChangelogFile();
+        if (current != null) {
+            return;
+        }
+        await writeFile(join(this.absolutePathToLocalOutput, RelativeFilePath.of(prior.filename)), prior.content);
+        this.context.logger.debug(`Restored ${prior.filename} removed during generation.`);
+    }
+
+    /**
+     * Prepends a version-only changelog entry (version header, empty description) for an
+     * explicitly pinned version. Skips when the version is already recorded. When no
+     * changelog file exists, one is created only if `createIfMissing` is set (SDK repos) —
+     * plain local filesystem outputs are left untouched.
+     */
+    private async prependExplicitVersionChangelogEntry({
+        version,
+        createIfMissing
+    }: {
+        version: string;
+        createIfMissing: boolean;
+    }): Promise<void> {
+        const existing = await this.readChangelogFile();
+        if (existing == null && !createIfMissing) {
+            return;
+        }
+        if (existing != null && changelogContainsVersion(existing.content, version)) {
+            return;
+        }
+        const filename = existing?.filename ?? "changelog.md";
+        await writeFile(
+            join(this.absolutePathToLocalOutput, RelativeFilePath.of(filename)),
+            prependChangelogBlock({ existingContent: existing?.content ?? "", version, entry: "" })
+        );
+        this.context.logger.debug(`Recorded version ${version} in ${filename}.`);
     }
 
     /**

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.explicitVersionChangelog.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.explicitVersionChangelog.test.ts
@@ -1,0 +1,111 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { mkdir, readdir, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LocalTaskHandler } from "../LocalTaskHandler.js";
+
+// Minimal stub for TaskContext to satisfy LocalTaskHandler constructor.
+function createMockContext(): LocalTaskHandler.Init["context"] {
+    const noop = () => {
+        // noop
+    };
+    return {
+        logger: { info: noop, debug: noop, warn: noop, error: noop }
+    } as LocalTaskHandler.Init["context"];
+}
+
+const PRIOR_CHANGELOG = `# Changelog
+
+## [1.0.0] - 2024-01-01
+- Initial release
+
+`;
+
+describe("LocalTaskHandler - explicit version changelog", () => {
+    let outputDir: string;
+    let tmpOutputDir: string;
+
+    function createHandler(version: string | undefined): LocalTaskHandler {
+        return new LocalTaskHandler({
+            context: createMockContext(),
+            absolutePathToTmpOutputDirectory: AbsoluteFilePath.of(tmpOutputDir),
+            absolutePathToTmpSnippetJSON: undefined,
+            absolutePathToLocalSnippetTemplateJSON: undefined,
+            absolutePathToLocalOutput: AbsoluteFilePath.of(outputDir),
+            absolutePathToLocalSnippetJSON: undefined,
+            absolutePathToTmpSnippetTemplatesJSON: undefined,
+            absolutePathToSpecRepo: undefined,
+            version,
+            ai: undefined,
+            isWhitelabel: false,
+            generatorLanguage: undefined
+        });
+    }
+
+    beforeEach(async () => {
+        const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        outputDir = join(tmpdir(), `explicit-changelog-out-${suffix}`);
+        tmpOutputDir = join(tmpdir(), `explicit-changelog-tmp-${suffix}`);
+        await mkdir(outputDir, { recursive: true });
+        await mkdir(tmpOutputDir, { recursive: true });
+        await writeFile(join(tmpOutputDir, "client.ts"), "export const client = {};\n");
+        await writeFile(join(tmpOutputDir, "README.md"), "# SDK\n");
+    });
+
+    afterEach(async () => {
+        await rm(outputDir, { recursive: true, force: true });
+        await rm(tmpOutputDir, { recursive: true, force: true });
+    });
+
+    it("preserves existing changelog entries and prepends a version-only entry in a git repo", async () => {
+        await mkdir(join(outputDir, ".git"), { recursive: true });
+        await writeFile(join(outputDir, "changelog.md"), PRIOR_CHANGELOG);
+
+        await createHandler("2.0.0").copyGeneratedFiles();
+
+        const changelog = await readFile(join(outputDir, "changelog.md"), "utf-8");
+        expect(changelog).toContain("## [2.0.0]");
+        expect(changelog).toContain("## [1.0.0] - 2024-01-01");
+        expect(changelog).toContain("- Initial release");
+        expect(changelog.indexOf("## [2.0.0]")).toBeLessThan(changelog.indexOf("## [1.0.0]"));
+    });
+
+    it("creates changelog.md with a version-only entry in a git repo without one", async () => {
+        await mkdir(join(outputDir, ".git"), { recursive: true });
+
+        await createHandler("0.1.0").copyGeneratedFiles();
+
+        const changelog = await readFile(join(outputDir, "changelog.md"), "utf-8");
+        expect(changelog).toContain("# Changelog");
+        expect(changelog).toContain("## [0.1.0]");
+    });
+
+    it("does not duplicate an entry when regenerating with the same version", async () => {
+        await mkdir(join(outputDir, ".git"), { recursive: true });
+        await writeFile(join(outputDir, "changelog.md"), PRIOR_CHANGELOG);
+
+        await createHandler("1.0.0").copyGeneratedFiles();
+
+        const changelog = await readFile(join(outputDir, "changelog.md"), "utf-8");
+        expect(changelog.match(/## \[1\.0\.0\]/g)).toHaveLength(1);
+    });
+
+    it("does not create changelog.md in a non-git output without a prior changelog", async () => {
+        await createHandler("0.1.0").copyGeneratedFiles();
+
+        const files = await readdir(outputDir);
+        expect(files.map((f) => f.toLowerCase())).not.toContain("changelog.md");
+    });
+
+    it("restores a wiped changelog even when no version is passed", async () => {
+        await mkdir(join(outputDir, ".git"), { recursive: true });
+        await writeFile(join(outputDir, "CHANGELOG.md"), PRIOR_CHANGELOG);
+
+        await createHandler(undefined).copyGeneratedFiles();
+
+        const changelog = await readFile(join(outputDir, "CHANGELOG.md"), "utf-8");
+        expect(changelog).toBe(PRIOR_CHANGELOG);
+    });
+});

--- a/packages/generator-cli/changes/unreleased/fix-explicit-version-changelog.yml
+++ b/packages/generator-cli/changes/unreleased/fix-explicit-version-changelog.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Explicitly versioned generations (`--version X.Y.Z`) now record a version-only entry in
+    `changelog.md`, and existing changelog entries are always preserved: GithubStep prepends
+    new entries instead of only creating a fresh file, and the GitHub push/PR flows restore a
+    tracked `changelog.md` that the generated output would otherwise delete.
+  type: fix

--- a/packages/generator-cli/src/__test__/changelog-utils.test.ts
+++ b/packages/generator-cli/src/__test__/changelog-utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { changelogContainsVersion, prependChangelogBlock } from "../autoversion/changelogUtils.js";
+
+describe("prependChangelogBlock", () => {
+    it("creates a fresh changelog with a title when there is no existing content", () => {
+        const result = prependChangelogBlock({
+            existingContent: "",
+            version: "1.2.0",
+            entry: "- Added a new endpoint",
+            date: "2026-07-09"
+        });
+        expect(result).toBe("# Changelog\n\n## [1.2.0] - 2026-07-09\n- Added a new endpoint\n\n");
+    });
+
+    it("prepends under an existing # Changelog title, preserving prior entries", () => {
+        const existing = "# Changelog\n\n## [1.0.0] - 2024-01-01\n- Initial release\n\n";
+        const result = prependChangelogBlock({
+            existingContent: existing,
+            version: "1.1.0",
+            entry: "- Fixed a bug",
+            date: "2026-07-09"
+        });
+        expect(result).toBe(
+            "# Changelog\n\n## [1.1.0] - 2026-07-09\n- Fixed a bug\n\n## [1.0.0] - 2024-01-01\n- Initial release\n\n"
+        );
+    });
+
+    it("prepends before content that has no # Changelog title", () => {
+        const existing = "## [1.0.0] - 2024-01-01\n- Initial release\n";
+        const result = prependChangelogBlock({
+            existingContent: existing,
+            version: "1.1.0",
+            entry: "- Fixed a bug",
+            date: "2026-07-09"
+        });
+        expect(result.startsWith("## [1.1.0] - 2026-07-09\n- Fixed a bug\n\n")).toBe(true);
+        expect(result).toContain("## [1.0.0] - 2024-01-01");
+    });
+
+    it("writes a version-only block when the entry is empty", () => {
+        const result = prependChangelogBlock({
+            existingContent: "",
+            version: "0.1.0",
+            entry: "",
+            date: "2026-07-09"
+        });
+        expect(result).toBe("# Changelog\n\n## [0.1.0] - 2026-07-09\n\n");
+    });
+
+    it("falls back to a date-only header when no version is available", () => {
+        const result = prependChangelogBlock({
+            existingContent: "",
+            version: undefined,
+            entry: "- Regenerated SDK",
+            date: "2026-07-09"
+        });
+        expect(result).toBe("# Changelog\n\n## 2026-07-09\n- Regenerated SDK\n\n");
+    });
+});
+
+describe("changelogContainsVersion", () => {
+    it("detects an existing version header", () => {
+        const content = "# Changelog\n\n## [1.0.0] - 2024-01-01\n- Initial release\n";
+        expect(changelogContainsVersion(content, "1.0.0")).toBe(true);
+    });
+
+    it("returns false when the version is not recorded", () => {
+        const content = "# Changelog\n\n## [1.0.0] - 2024-01-01\n- Initial release\n";
+        expect(changelogContainsVersion(content, "1.1.0")).toBe(false);
+    });
+});

--- a/packages/generator-cli/src/autoversion/changelogUtils.ts
+++ b/packages/generator-cli/src/autoversion/changelogUtils.ts
@@ -41,5 +41,6 @@ export function prependChangelogBlock({
  * so callers can avoid prepending a duplicate block on regeneration.
  */
 export function changelogContainsVersion(content: string, version: string): boolean {
-    return content.includes(`## [${version}]`);
+    const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`^## \\[${escaped}\\]`, "m").test(content);
 }

--- a/packages/generator-cli/src/autoversion/changelogUtils.ts
+++ b/packages/generator-cli/src/autoversion/changelogUtils.ts
@@ -1,0 +1,45 @@
+/**
+ * Utilities for maintaining an SDK repo's `changelog.md`. Entries are markdown
+ * blocks headed by `## [<version>] - <date>` with the most recent entry at the
+ * top, under an optional `# Changelog` title line.
+ */
+
+/**
+ * Prepends a changelog block for `version` to `existingContent`, preserving all
+ * existing entries. When `entry` is empty (e.g. an explicitly pinned version with
+ * no generated description), the block consists of just the version header.
+ */
+export function prependChangelogBlock({
+    existingContent,
+    version,
+    entry,
+    date = new Date().toISOString().slice(0, 10)
+}: {
+    existingContent: string;
+    version: string | undefined;
+    entry: string;
+    date?: string;
+}): string {
+    const header = version != null ? `## [${version}] - ${date}\n` : `## ${date}\n`;
+    const trimmedEntry = entry.trim();
+    const newBlock = trimmedEntry.length > 0 ? `${header}${trimmedEntry}\n\n` : `${header}\n`;
+
+    if (existingContent.trim().length === 0) {
+        return `# Changelog\n\n${newBlock}`;
+    }
+    if (existingContent.startsWith("# Changelog")) {
+        const newlineIdx = existingContent.indexOf("\n");
+        const headerLine = newlineIdx >= 0 ? existingContent.slice(0, newlineIdx) : existingContent;
+        const remainder = (newlineIdx >= 0 ? existingContent.slice(newlineIdx + 1) : "").replace(/^\s*\n/, "");
+        return `${headerLine}\n\n${newBlock}${remainder}`;
+    }
+    return `${newBlock}${existingContent}`;
+}
+
+/**
+ * Returns true when `content` already has an entry header for `version`,
+ * so callers can avoid prepending a duplicate block on regeneration.
+ */
+export function changelogContainsVersion(content: string, version: string): boolean {
+    return content.includes(`## [${version}]`);
+}

--- a/packages/generator-cli/src/autoversion/index.ts
+++ b/packages/generator-cli/src/autoversion/index.ts
@@ -6,6 +6,7 @@ export {
     countFilesInDiff,
     formatSizeKB
 } from "./AutoVersioningService.js";
+export { changelogContainsVersion, prependChangelogBlock } from "./changelogUtils.js";
 export {
     AUTO_VERSION,
     extractLanguageFromGeneratorName,

--- a/packages/generator-cli/src/github/GitHub.ts
+++ b/packages/generator-cli/src/github/GitHub.ts
@@ -7,6 +7,7 @@ import {
     parseRepository
 } from "@fern-api/github";
 import { Octokit } from "@octokit/rest";
+import { readdir } from "fs/promises";
 
 import type { FernGeneratorCli } from "../configuration/sdk/index.js";
 
@@ -45,9 +46,10 @@ export class GitHub {
             }
 
             const fernIgnoreFiles = await this.getFernignoreFiles(repository);
+            const changelogFiles = await this.getChangelogFilesToPreserve(repository, sourceDirectory);
             await repository.overwriteLocalContents(sourceDirectory);
             await repository.add(".");
-            await this.restoreFiles(repository, fernIgnoreFiles);
+            await this.restoreFiles(repository, [...fernIgnoreFiles, ...changelogFiles]);
             await repository.commit("SDK Generation");
 
             if (isEmptyRepo) {
@@ -92,9 +94,10 @@ export class GitHub {
             await repository.checkout(prBranch);
 
             const fernIgnoreFiles = await this.getFernignoreFiles(repository);
+            const changelogFiles = await this.getChangelogFilesToPreserve(repository, sourceDirectory);
             await repository.overwriteLocalContents(sourceDirectory);
             await repository.add(".");
-            await this.restoreFiles(repository, fernIgnoreFiles);
+            await this.restoreFiles(repository, [...fernIgnoreFiles, ...changelogFiles]);
             await repository.commit("SDK Generation");
             await repository.push();
 
@@ -144,6 +147,29 @@ export class GitHub {
         }
         const tracked = await repository.listTrackedFiles();
         return expandFernignorePatterns(fernignore, tracked);
+    }
+
+    /**
+     * Returns tracked changelog files (e.g. `changelog.md`) that should be restored after
+     * `overwriteLocalContents`, so existing changelog entries are never wiped when the
+     * generated output doesn't include a changelog of its own.
+     */
+    private async getChangelogFilesToPreserve(
+        repository: ClonedRepository,
+        sourceDirectory: string
+    ): Promise<string[]> {
+        const tracked = await repository.listTrackedFiles();
+        const trackedChangelogs = tracked.filter((file) => file.toLowerCase() === "changelog.md");
+        if (trackedChangelogs.length === 0) {
+            return [];
+        }
+        try {
+            const sourceFiles = await readdir(sourceDirectory);
+            const sourceHasChangelog = sourceFiles.some((file) => file.toLowerCase() === "changelog.md");
+            return sourceHasChangelog ? [] : trackedChangelogs;
+        } catch {
+            return trackedChangelogs;
+        }
     }
 
     private async restoreFiles(repository: ClonedRepository, files: string[]): Promise<void> {

--- a/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
@@ -15,7 +15,8 @@ import {
     MAX_CHUNKS,
     MAX_RAW_DIFF_BYTES,
     mapMagicVersionForLanguage,
-    maxVersionBump
+    maxVersionBump,
+    prependChangelogBlock
 } from "../../autoversion/index";
 import type { PreparedReplay } from "../../replay/replay-run";
 import type { PipelineLogger } from "../PipelineLogger";
@@ -717,28 +718,13 @@ export class AutoVersionStep extends BaseStep {
     private async prependChangelogEntry(params: { version: string; entry: string }): Promise<void> {
         const { version, entry } = params;
         const changelogPath = join(this.outputDir, "changelog.md");
-        const now = new Date().toISOString().slice(0, 10);
-        const header = `## [${version}] - ${now}\n`;
-        const newBlock = `${header}${entry.trim()}\n\n`;
 
         let existing = "";
         if (existsSync(changelogPath)) {
             existing = await readFile(changelogPath, "utf-8");
         }
 
-        let output: string;
-        if (existing.trim().length === 0) {
-            output = `# Changelog\n\n${newBlock}`;
-        } else if (existing.startsWith("# Changelog")) {
-            const newlineIdx = existing.indexOf("\n");
-            const headerLine = newlineIdx >= 0 ? existing.slice(0, newlineIdx) : existing;
-            const remainder = (newlineIdx >= 0 ? existing.slice(newlineIdx + 1) : "").replace(/^\s*\n/, "");
-            output = `${headerLine}\n\n${newBlock}${remainder}`;
-        } else {
-            output = `${newBlock}${existing}`;
-        }
-
-        await writeFile(changelogPath, output, "utf-8");
+        await writeFile(changelogPath, prependChangelogBlock({ existingContent: existing, version, entry }), "utf-8");
     }
 
     private brandMessage(message: string): string {

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -1,8 +1,9 @@
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { ClonedRepository, parseRepository } from "@fern-api/github";
 import { Octokit } from "@octokit/rest";
-import { access, writeFile } from "fs/promises";
+import { access, readFile, writeFile } from "fs/promises";
 import { join } from "path";
+import { changelogContainsVersion, prependChangelogBlock } from "../../autoversion/index";
 import { createReplayBranch } from "../github/createReplayBranch";
 import { findExistingUpdatablePR } from "../github/findExistingUpdatablePR";
 import { parseCommitMessageForPR } from "../github/parseCommitMessage";
@@ -484,32 +485,45 @@ export class GithubStep extends BaseStep {
     }
 
     /**
-     * Guarantees `changelog.md` is present in the output directory whenever a changelog entry
-     * exists for this run, so the file lands in the committed tree that GithubStep pushes and the
+     * Guarantees `changelog.md` records this run whenever there is a changelog entry or a
+     * resolved version, so the file lands in the committed tree that GithubStep pushes and the
      * "See full changelog" link resolves. AutoVersionStep normally writes this file via
-     * `prependChangelogEntry`; this is a safety net for paths where that write never reached the
-     * directory GithubStep commits (e.g. non-replay self-hosted generation), which previously left
-     * the link pointing at a non-existent blob (404).
+     * `prependChangelogEntry`; this covers the paths where that write never reached the
+     * directory GithubStep commits (e.g. non-replay self-hosted generation) and explicitly
+     * versioned runs (`--version X.Y.Z`), which record a version-only entry with an empty
+     * description. Existing entries are always preserved — the new block is prepended.
      *
-     * Returns `true` when it created the file, `false` when the file already existed (or there is
-     * no changelog entry to write).
+     * Returns `true` when it created or modified the file, `false` when the version's entry was
+     * already recorded (e.g. by AutoVersionStep) or there is nothing to write.
      */
     private async ensureChangelogFile(resolved: ResolvedPrFields): Promise<boolean> {
-        const entry = resolved.changelogEntry?.trim();
-        if (entry == null || entry.length === 0) {
+        const entry = resolved.changelogEntry?.trim() ?? "";
+        const version = resolved.newVersion ?? resolved.previousVersion;
+        // A version-only entry (empty description) is only recorded for runs that produced a
+        // new version (e.g. an explicit `--version X.Y.Z`).
+        if (entry.length === 0 && resolved.newVersion == null) {
             return false;
         }
         const changelogPath = join(this.outputDir, "changelog.md");
+        let existing: string | undefined;
         try {
-            await access(changelogPath);
-            // Already written (e.g. by AutoVersionStep) — don't duplicate the entry.
-            return false;
+            existing = await readFile(changelogPath, "utf-8");
         } catch {
-            const version = resolved.newVersion ?? resolved.previousVersion;
-            await writeFile(changelogPath, buildChangelogFileContents(entry, version), "utf-8");
-            this.logger.debug(`Wrote changelog.md${version != null ? ` for ${version}` : ""}.`);
-            return true;
+            existing = undefined;
         }
+        if (existing != null) {
+            if (version == null || changelogContainsVersion(existing, version)) {
+                // Already written (e.g. by AutoVersionStep) — don't duplicate the entry.
+                return false;
+            }
+        }
+        await writeFile(
+            changelogPath,
+            prependChangelogBlock({ existingContent: existing ?? "", version, entry }),
+            "utf-8"
+        );
+        this.logger.debug(`Wrote changelog.md${version != null ? ` for ${version}` : ""}.`);
+        return true;
     }
 
     private deriveSkipCommit(replayResult: ReplayStepResult | undefined): boolean {


### PR DESCRIPTION
## Description
Linear ticket: N/A

`fern generate --group <group> --version 0.1.0` (explicit version, not AUTO) skipped the autoversioning pipeline entirely, so no changelog entry was written — and regeneration copy steps could wipe an existing `changelog.md`, losing version history forever.

Now:
- Explicit versions record a version-only entry: `## [0.1.0] - <date>` with an empty description, prepended to the existing changelog.
- `--version AUTO` keeps its AI-generated changelog flow unchanged.
- `changelog.md` is never wiped: existing entries are always preserved across regenerations.

## Changes Made
- New `autoversion/changelogUtils.ts` with `prependChangelogBlock()` (prepends a `## [version] - date` block while preserving existing content and the `# Changelog` title) and `changelogContainsVersion()` (duplicate-entry guard); `AutoVersionStep.prependChangelogEntry()` now delegates to it.
- `LocalTaskHandler.copyGeneratedFiles()`:
  - captures `changelog.md` (case-insensitive) before copy operations and restores it if the copy removed it (generators don't emit changelog.md);
  - for explicit (non-AUTO) versions, prepends a version-only entry, skipping duplicates; a new file is only created when the output is a git repo.
- `GithubStep.ensureChangelogFile()` now prepends into an existing changelog instead of only creating a missing file, and writes a version-only entry when a new version has no changelog entry (explicit-version runs); duplicate versions are skipped.
- `GitHub.push()` / `GitHub.pr()` (generator-agent flow) restore a tracked `changelog.md` after `overwriteLocalContents` when the generated output doesn't include one, so existing entries are never deleted.
- Changelog entries added under `packages/cli/cli/changes/unreleased/` and `packages/generator-cli/changes/unreleased/` (type: fix).
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated: `changelog-utils.test.ts` (prepend/duplicate/format cases) and `LocalTaskHandler.explicitVersionChangelog.test.ts` (preserve + prepend in git repos, no duplicates on regeneration with same version, restore of wiped changelog, no file created for plain local output)
- [x] Manual testing completed: `pnpm turbo run test --filter @fern-api/generator-cli --filter @fern-api/local-workspace-runner` — all 626 tests pass; `pnpm lint:biome` and `pnpm format` clean


Link to Devin session: https://app.devin.ai/sessions/1d8601f644ca491592d79696962aa730
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->