### PR TITLE
fix(python): expose basic auth credentials on the root client when OAuth is also configured

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-basic-auth-with-oauth.yml
+++ b/generators/python/sdk/changes/unreleased/fix-basic-auth-with-oauth.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Expose basic auth credentials (e.g. `account_sid` / `auth_token`) on the top-level
+    client when the API also configures OAuth (`auth: any`). Previously the root client
+    constructor only accepted OAuth client credentials or a bearer token, even though the
+    underlying client wrapper supported basic auth. The credentials are now optional
+    constructor parameters that are forwarded to the client wrapper, and the client can be
+    instantiated with basic auth alone without raising an error.
+  type: fix

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -1490,13 +1490,16 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
             )
             writer.write_newline_if_last_line_not()
 
-        # else: fall back to header-auth-only or raise error
-        has_header_auth_schemes = len(client_wrapper_generator._get_header_auth_schemes()) > 0
+        # else: fall back to non-OAuth auth schemes or raise error
+        has_non_oauth_auth_schemes = (
+            len(client_wrapper_generator._get_header_auth_schemes()) > 0
+            or client_wrapper_generator._get_basic_auth_scheme() is not None
+        )
         writer.write_line("else:")
         with writer.indent():
-            if has_header_auth_schemes:
-                # When header auth schemes exist (e.g. api_key via auth: any), allow constructing
-                # the client without a bearer token — the header auth alone is sufficient.
+            if has_non_oauth_auth_schemes:
+                # When other auth schemes exist (e.g. api_key or basic auth via auth: any), allow
+                # constructing the client without a bearer token — that auth alone is sufficient.
                 header_only_kwargs = self._get_client_wrapper_kwargs(
                     client_wrapper_generator=client_wrapper_generator,
                     environments_config=self._environments_config,

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -897,6 +897,122 @@ class ClientWrapperGenerator:
                 )
             )
 
+        # Basic auth is independent of bearer/OAuth auth and must always be included —
+        # even when exclude_auth is True (OAuth token override mode). When OAuth is also
+        # present (auth: any), make the credentials optional so users can authenticate
+        # with either OAuth or basic auth alone.
+        basic_auth_scheme = self._get_basic_auth_scheme()
+        basic_auth_is_required = self._context.ir.sdk_config.is_auth_mandatory and not self._has_oauth()
+        if basic_auth_scheme is not None:
+            username_omitted = basic_auth_scheme.username_omit is True
+            password_omitted = basic_auth_scheme.password_omit is True
+
+            # When omit is true, the field is completely removed from the end-user API.
+            # Only add non-omitted fields to constructor parameters.
+            if not username_omitted:
+                username_constructor_parameter_name = names.get_username_constructor_parameter_name(basic_auth_scheme)
+                username_constructor_parameter = ConstructorParameter(
+                    constructor_parameter_name=username_constructor_parameter_name,
+                    private_member_name=names.get_username_member_name(basic_auth_scheme),
+                    type_hint=(
+                        ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT
+                        if basic_auth_is_required
+                        else AST.TypeHint.optional(ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT)
+                    ),
+                    initializer=AST.Expression(
+                        f'{username_constructor_parameter_name}="YOUR_{resolve_name(basic_auth_scheme.username).screaming_snake_case.safe_name}"',
+                    ),
+                    getter_method=AST.FunctionDeclaration(
+                        name=names.get_username_getter_name(basic_auth_scheme),
+                        signature=AST.FunctionSignature(
+                            parameters=[],
+                            return_type=(
+                                AST.TypeHint.str_()
+                                if basic_auth_is_required
+                                else AST.TypeHint.optional(AST.TypeHint.str_())
+                            ),
+                        ),
+                        body=AST.CodeWriter(
+                            self._get_required_getter_body_writer(
+                                member_name=names.get_username_member_name(basic_auth_scheme)
+                            )
+                            if basic_auth_is_required
+                            else self._get_optional_getter_body_writer(
+                                member_name=names.get_username_member_name(basic_auth_scheme)
+                            )
+                        ),
+                    ),
+                    environment_variable=(
+                        basic_auth_scheme.username_env_var if basic_auth_scheme.username_env_var is not None else None
+                    ),
+                    is_basic=True,
+                    template=TemplateGenerator.string_template(
+                        is_optional=False,
+                        template_string_prefix=username_constructor_parameter_name,
+                        inputs=[
+                            TemplateInput.factory.payload(
+                                PayloadInput(
+                                    location="AUTH",
+                                    path="username",
+                                )
+                            ),
+                        ],
+                    ),
+                )
+                parameters.append(username_constructor_parameter)
+
+            if not password_omitted:
+                password_constructor_parameter_name = names.get_password_constructor_parameter_name(basic_auth_scheme)
+                password_constructor_parameter = ConstructorParameter(
+                    constructor_parameter_name=password_constructor_parameter_name,
+                    private_member_name=names.get_password_member_name(basic_auth_scheme),
+                    type_hint=(
+                        ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT
+                        if basic_auth_is_required
+                        else AST.TypeHint.optional(ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT)
+                    ),
+                    initializer=AST.Expression(
+                        f'{password_constructor_parameter_name}="YOUR_{resolve_name(basic_auth_scheme.password).screaming_snake_case.safe_name}"',
+                    ),
+                    getter_method=AST.FunctionDeclaration(
+                        name=names.get_password_getter_name(basic_auth_scheme),
+                        signature=AST.FunctionSignature(
+                            parameters=[],
+                            return_type=(
+                                AST.TypeHint.str_()
+                                if basic_auth_is_required
+                                else AST.TypeHint.optional(AST.TypeHint.str_())
+                            ),
+                        ),
+                        body=AST.CodeWriter(
+                            self._get_required_getter_body_writer(
+                                member_name=names.get_password_member_name(basic_auth_scheme)
+                            )
+                            if basic_auth_is_required
+                            else self._get_optional_getter_body_writer(
+                                member_name=names.get_password_member_name(basic_auth_scheme)
+                            )
+                        ),
+                    ),
+                    is_basic=True,
+                    environment_variable=(
+                        basic_auth_scheme.password_env_var if basic_auth_scheme.password_env_var is not None else None
+                    ),
+                    template=TemplateGenerator.string_template(
+                        is_optional=False,
+                        template_string_prefix=password_constructor_parameter_name,
+                        inputs=[
+                            TemplateInput.factory.payload(
+                                PayloadInput(
+                                    location="AUTH",
+                                    path="password",
+                                )
+                            ),
+                        ],
+                    ),
+                )
+                parameters.append(password_constructor_parameter)
+
         if exclude_auth:
             # Add generic headers parameter even when excluding auth
             parameters.append(headers_constructor_parameter)
@@ -977,117 +1093,6 @@ class ClientWrapperGenerator:
                     ),
                 )
             )
-
-        basic_auth_scheme = self._get_basic_auth_scheme()
-        if basic_auth_scheme is not None:
-            username_omitted = basic_auth_scheme.username_omit is True
-            password_omitted = basic_auth_scheme.password_omit is True
-
-            # When omit is true, the field is completely removed from the end-user API.
-            # Only add non-omitted fields to constructor parameters.
-            if not username_omitted:
-                username_constructor_parameter_name = names.get_username_constructor_parameter_name(basic_auth_scheme)
-                username_constructor_parameter = ConstructorParameter(
-                    constructor_parameter_name=username_constructor_parameter_name,
-                    private_member_name=names.get_username_member_name(basic_auth_scheme),
-                    type_hint=(
-                        ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT
-                        if self._context.ir.sdk_config.is_auth_mandatory
-                        else AST.TypeHint.optional(ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT)
-                    ),
-                    initializer=AST.Expression(
-                        f'{username_constructor_parameter_name}="YOUR_{resolve_name(basic_auth_scheme.username).screaming_snake_case.safe_name}"',
-                    ),
-                    getter_method=AST.FunctionDeclaration(
-                        name=names.get_username_getter_name(basic_auth_scheme),
-                        signature=AST.FunctionSignature(
-                            parameters=[],
-                            return_type=(
-                                AST.TypeHint.str_()
-                                if self._context.ir.sdk_config.is_auth_mandatory
-                                else AST.TypeHint.optional(AST.TypeHint.str_())
-                            ),
-                        ),
-                        body=AST.CodeWriter(
-                            self._get_required_getter_body_writer(
-                                member_name=names.get_username_member_name(basic_auth_scheme)
-                            )
-                            if self._context.ir.sdk_config.is_auth_mandatory
-                            else self._get_optional_getter_body_writer(
-                                member_name=names.get_username_member_name(basic_auth_scheme)
-                            )
-                        ),
-                    ),
-                    environment_variable=(
-                        basic_auth_scheme.username_env_var if basic_auth_scheme.username_env_var is not None else None
-                    ),
-                    is_basic=True,
-                    template=TemplateGenerator.string_template(
-                        is_optional=False,
-                        template_string_prefix=username_constructor_parameter_name,
-                        inputs=[
-                            TemplateInput.factory.payload(
-                                PayloadInput(
-                                    location="AUTH",
-                                    path="username",
-                                )
-                            ),
-                        ],
-                    ),
-                )
-                parameters.append(username_constructor_parameter)
-
-            if not password_omitted:
-                password_constructor_parameter_name = names.get_password_constructor_parameter_name(basic_auth_scheme)
-                password_constructor_parameter = ConstructorParameter(
-                    constructor_parameter_name=password_constructor_parameter_name,
-                    private_member_name=names.get_password_member_name(basic_auth_scheme),
-                    type_hint=(
-                        ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT
-                        if self._context.ir.sdk_config.is_auth_mandatory
-                        else AST.TypeHint.optional(ClientWrapperGenerator.STRING_OR_SUPPLIER_TYPE_HINT)
-                    ),
-                    initializer=AST.Expression(
-                        f'{password_constructor_parameter_name}="YOUR_{resolve_name(basic_auth_scheme.password).screaming_snake_case.safe_name}"',
-                    ),
-                    getter_method=AST.FunctionDeclaration(
-                        name=names.get_password_getter_name(basic_auth_scheme),
-                        signature=AST.FunctionSignature(
-                            parameters=[],
-                            return_type=(
-                                AST.TypeHint.str_()
-                                if self._context.ir.sdk_config.is_auth_mandatory
-                                else AST.TypeHint.optional(AST.TypeHint.str_())
-                            ),
-                        ),
-                        body=AST.CodeWriter(
-                            self._get_required_getter_body_writer(
-                                member_name=names.get_password_member_name(basic_auth_scheme)
-                            )
-                            if self._context.ir.sdk_config.is_auth_mandatory
-                            else self._get_optional_getter_body_writer(
-                                member_name=names.get_password_member_name(basic_auth_scheme)
-                            )
-                        ),
-                    ),
-                    is_basic=True,
-                    environment_variable=(
-                        basic_auth_scheme.password_env_var if basic_auth_scheme.password_env_var is not None else None
-                    ),
-                    template=TemplateGenerator.string_template(
-                        is_optional=False,
-                        template_string_prefix=password_constructor_parameter_name,
-                        inputs=[
-                            TemplateInput.factory.payload(
-                                PayloadInput(
-                                    location="AUTH",
-                                    path="password",
-                                )
-                            ),
-                        ],
-                    ),
-                )
-                parameters.append(password_constructor_parameter)
 
         # Add generic headers parameter
         parameters.append(headers_constructor_parameter)

--- a/seed/python-sdk/any-auth/src/seed/client.py
+++ b/seed/python-sdk/any-auth/src/seed/client.py
@@ -89,6 +89,8 @@ class SeedAnyAuth:
         *,
         base_url: str,
         api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
+        username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_USERNAME"),
+        password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_PASSWORD"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -106,6 +108,8 @@ class SeedAnyAuth:
         *,
         base_url: str,
         api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
+        username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_USERNAME"),
+        password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_PASSWORD"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -121,6 +125,8 @@ class SeedAnyAuth:
         *,
         base_url: str,
         api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
+        username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_USERNAME"),
+        password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_PASSWORD"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         client_id: typing.Optional[str] = os.getenv("MY_CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("MY_CLIENT_SECRET"),
@@ -140,6 +146,8 @@ class SeedAnyAuth:
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
                 api_key=api_key,
+                username=username,
+                password=password,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -160,6 +168,8 @@ class SeedAnyAuth:
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     api_key=api_key,
+                    username=username,
+                    password=password,
                     headers=headers,
                     httpx_client=httpx_client
                     if httpx_client is not None
@@ -176,6 +186,8 @@ class SeedAnyAuth:
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
                 api_key=api_key,
+                username=username,
+                password=password,
                 headers=headers,
                 token=_token_getter_override if _token_getter_override is not None else oauth_token_provider.get_token,
                 httpx_client=httpx_client
@@ -193,6 +205,8 @@ class SeedAnyAuth:
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
                 api_key=api_key,
+                username=username,
+                password=password,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -317,6 +331,8 @@ class AsyncSeedAnyAuth:
         *,
         base_url: str,
         api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
+        username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_USERNAME"),
+        password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_PASSWORD"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -334,6 +350,8 @@ class AsyncSeedAnyAuth:
         *,
         base_url: str,
         api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
+        username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_USERNAME"),
+        password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_PASSWORD"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -349,6 +367,8 @@ class AsyncSeedAnyAuth:
         *,
         base_url: str,
         api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
+        username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_USERNAME"),
+        password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("MY_PASSWORD"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         client_id: typing.Optional[str] = os.getenv("MY_CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("MY_CLIENT_SECRET"),
@@ -368,6 +388,8 @@ class AsyncSeedAnyAuth:
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
                 api_key=api_key,
+                username=username,
+                password=password,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -386,6 +408,8 @@ class AsyncSeedAnyAuth:
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     api_key=api_key,
+                    username=username,
+                    password=password,
                     headers=headers,
                     httpx_client=httpx_client
                     if httpx_client is not None
@@ -402,6 +426,8 @@ class AsyncSeedAnyAuth:
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
                 api_key=api_key,
+                username=username,
+                password=password,
                 headers=headers,
                 token=_token_getter_override,
                 async_token=oauth_token_provider.get_token,
@@ -418,6 +444,8 @@ class AsyncSeedAnyAuth:
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
                 api_key=api_key,
+                username=username,
+                password=password,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None

--- a/seed/python-sdk/any-auth/src/seed/core/client_wrapper.py
+++ b/seed/python-sdk/any-auth/src/seed/core/client_wrapper.py
@@ -12,10 +12,10 @@ class BaseClientWrapper:
         self,
         *,
         api_key: typing.Optional[str] = None,
-        auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
+        auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
+        token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
@@ -25,10 +25,10 @@ class BaseClientWrapper:
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
         self.api_key = api_key
-        self._auth_headers = auth_headers
-        self._token = token
         self._username = username
         self._password = password
+        self._auth_headers = auth_headers
+        self._token = token
         self._headers = headers
         self._base_url = base_url
         self._timeout = timeout
@@ -62,12 +62,6 @@ class BaseClientWrapper:
             headers.update(self._auth_headers())
         return headers
 
-    def _get_token(self) -> typing.Optional[str]:
-        if isinstance(self._token, str) or self._token is None:
-            return self._token
-        else:
-            return self._token()
-
     def _get_username(self) -> typing.Optional[str]:
         if isinstance(self._username, str) or self._username is None:
             return self._username
@@ -79,6 +73,12 @@ class BaseClientWrapper:
             return self._password
         else:
             return self._password()
+
+    def _get_token(self) -> typing.Optional[str]:
+        if isinstance(self._token, str) or self._token is None:
+            return self._token
+        else:
+            return self._token()
 
     def get_custom_headers(self) -> typing.Optional[typing.Dict[str, str]]:
         return self._headers
@@ -104,10 +104,10 @@ class SyncClientWrapper(BaseClientWrapper):
         self,
         *,
         api_key: typing.Optional[str] = None,
-        auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
+        auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
+        token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
@@ -119,10 +119,10 @@ class SyncClientWrapper(BaseClientWrapper):
     ):
         super().__init__(
             api_key=api_key,
-            auth_headers=auth_headers,
-            token=token,
             username=username,
             password=password,
+            auth_headers=auth_headers,
+            token=token,
             headers=headers,
             base_url=base_url,
             timeout=timeout,
@@ -146,10 +146,10 @@ class AsyncClientWrapper(BaseClientWrapper):
         self,
         *,
         api_key: typing.Optional[str] = None,
-        auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
+        auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
+        token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
@@ -163,10 +163,10 @@ class AsyncClientWrapper(BaseClientWrapper):
     ):
         super().__init__(
             api_key=api_key,
-            auth_headers=auth_headers,
-            token=token,
             username=username,
             password=password,
+            auth_headers=auth_headers,
+            token=token,
             headers=headers,
             base_url=base_url,
             timeout=timeout,


### PR DESCRIPTION
## Description
When an API configures both OAuth client credentials and basic auth (`auth: any`), the generated root client only accepted `client_id`/`client_secret` or a bearer `token` — basic auth credentials (e.g. Twilio's `account_sid`/`auth_token`) were not exposed even though the generated `ClientWrapper` fully supports them and builds the `Authorization: Basic ...` header. Instantiating with only basic auth also raised `ApiError: The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'`.

This PR makes the client wrapper generator emit basic auth constructor parameters even in OAuth token-override mode (they were previously skipped by the `exclude_auth` early return), makes them optional when OAuth is present, and forwards them from the root client to the wrapper. The root client's fallback branch now also constructs the wrapper (instead of raising) when a basic auth scheme exists.

Generated output before/after (Twilio Core config):

```python
# before
TwilioApi(account_sid="AC...", auth_token="...")  # TypeError: unexpected keyword argument 'account_sid'

# after
def __init__(
    self,
    *,
    environment: TwilioApiEnvironment = TwilioApiEnvironment.DEFAULT,
    account_sid: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("TWILIO_ACCOUNT_SID"),
    auth_token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = os.getenv("TWILIO_AUTH_TOKEN"),
    client_id: typing.Optional[str] = os.getenv("OAUTH_CLIENT_ID"),
    ...
```

## Changes Made
- `client_wrapper_generator.py`: move basic auth constructor-parameter generation before the `exclude_auth` early return; credentials become optional when OAuth is configured (`basic_auth_is_required = is_auth_mandatory and not has_oauth`)
- `root_client_generator.py`: the `else` fallback branch in OAuth token-override mode now constructs the client wrapper when a basic auth scheme exists, instead of raising `ApiError`
- Updated `seed/python-sdk/any-auth` snapshots (sync + async clients now accept and forward `username`/`password`)
- Added changelog entry under `generators/python/sdk/changes/unreleased/`

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- `pnpm seed test --generator python-sdk --fixture basic-auth|any-auth|oauth-client-credentials --skip-scripts` — all pass
- Regenerated the Twilio Core SDK locally: `account_sid`/`auth_token` are exposed and forwarded; `poetry run mypy .` on the generated SDK passes (948 files, no issues)
- `poetry run pre-commit` and `mypy` on the modified generator files pass


Link to Devin session: https://app.devin.ai/sessions/c6a76f42ee5f427d8e24de84e772d7fb
Requested by: @iamnamananand996